### PR TITLE
Add support for calculating taxes by avatax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Saleor Avatax App
 
-> **Warning** The app is work in progress. Not ready to use.
-
 The sales tax calculation with using [Avatax API](https://developer.avalara.com/avatax/).
 
 The app uses synchronous webhooks: `checkout-calculate-taxes`, `order-calculate-taxes`, to calculate sales taxes for Saleor.

--- a/__tests__/backend/avataxApi.test.ts
+++ b/__tests__/backend/avataxApi.test.ts
@@ -1,0 +1,152 @@
+import { AvataxConfig } from "../../backend/types";
+import {
+  dummyFetchTaxesPayload,
+  dummyFetchTaxesResponse,
+  dummyAvataxConfig,
+} from "../utils";
+import Avatax from "ava-typescript";
+import { fetchTaxes } from "../../backend/avataxApi";
+
+describe("Avatax API handlers", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("fetches taxes from avatax", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const payload = dummyFetchTaxesPayload;
+    const config: AvataxConfig = dummyAvataxConfig;
+
+    await fetchTaxes(payload, config, "SalesOrder");
+
+    expect(mockedCreateTransaction).toHaveBeenCalledWith({
+      model: {
+        type: 0,
+        companyCode: "DEFAULT",
+        code: "234",
+        date: new Date("2022-05-04"),
+        customerCode: "0",
+        discount: 10,
+        commit: false,
+        currencyCode: "USD",
+        lines: [
+          {
+            amount: 20,
+            number: "1",
+            description: "Apple Juice",
+            discounted: true,
+            itemCode: "sku123",
+            quantity: 1,
+            taxCode: "",
+            taxIncluded: true,
+            taxOverride: undefined,
+          },
+          {
+            number: "",
+            amount: 10,
+            description: "",
+            discounted: true,
+            itemCode: "Shipping",
+            quantity: 1,
+            taxCode: "FR000000",
+            taxIncluded: true,
+          },
+        ],
+        addresses: {
+          shipTo: {
+            city: "Wroclaw",
+            country: "PL",
+            line1: "Teczowa 777",
+            line2: "",
+            line3: "",
+            postalCode: "53-601",
+            region: "Dolnoslaskie",
+            locationCode: "",
+          },
+          shipFrom: {
+            city: "Wroclaw",
+            country: "PL",
+            line1: "Teczowa 7",
+            line2: "",
+            line3: "",
+            postalCode: "50-601",
+            region: "",
+          },
+        },
+      },
+    });
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it("creates invoice on Avatax side", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const payload = dummyFetchTaxesPayload;
+    const config: AvataxConfig = dummyAvataxConfig;
+
+    await fetchTaxes(payload, config, "SalesInvoice");
+
+    expect(mockedCreateTransaction).toHaveBeenCalledWith({
+      model: {
+        type: 1,
+        companyCode: "DEFAULT",
+        code: "234",
+        date: new Date("2022-05-04"),
+        customerCode: "0",
+        discount: 10,
+        commit: false,
+        currencyCode: "USD",
+        lines: [
+          {
+            number: "1",
+            amount: 20,
+            description: "Apple Juice",
+            discounted: true,
+            itemCode: "sku123",
+            quantity: 1,
+            taxCode: "",
+            taxIncluded: true,
+          },
+          {
+            number: "",
+            amount: 10,
+            description: "",
+            discounted: true,
+            itemCode: "Shipping",
+            quantity: 1,
+            taxCode: "FR000000",
+            taxIncluded: true,
+          },
+        ],
+        addresses: {
+          shipTo: {
+            city: "Wroclaw",
+            country: "PL",
+            line1: "Teczowa 777",
+            line2: "",
+            line3: "",
+            postalCode: "53-601",
+            region: "Dolnoslaskie",
+            locationCode: "",
+          },
+          shipFrom: {
+            city: "Wroclaw",
+            country: "PL",
+            line1: "Teczowa 7",
+            line2: "",
+            line3: "",
+            postalCode: "50-601",
+            region: "",
+          },
+        },
+      },
+    });
+    mockedCreateTransaction.mockRestore();
+  });
+});

--- a/__tests__/pages/webhooks/checkout-calculate-taxes.test.ts
+++ b/__tests__/pages/webhooks/checkout-calculate-taxes.test.ts
@@ -1,0 +1,543 @@
+/** @jest-environment setup-polly-jest/jest-environment-node */
+import { PollyServer } from "@pollyjs/core";
+import { ResponseTaxPayload } from "../../../backend/types";
+import { setupPollyMiddleware, setupRecording } from "../../pollySetup";
+import {
+  dummyCalculateTaxesPayloadForCheckout,
+  dummyFetchTaxesResponse,
+  mockRequest,
+} from "../../utils";
+import Avatax from "ava-typescript";
+
+import * as joseModule from "jose";
+import { NextApiRequest, NextApiResponse } from "next";
+import toNextHandler from "../../../pages/api/webhooks/checkout-calculate-taxes";
+
+jest.mock("next/dist/compiled/raw-body/index.js", () => ({
+  __esModule: true,
+  default: jest.fn((_) => ({
+    toString: () => '{"dummy":12}',
+  })),
+}));
+
+const testDomain = "localhost:8000";
+describe("api/webhooks/checkout-calculate-taxes", () => {
+  const context = setupRecording();
+  beforeEach(() => {
+    process.env.SALEOR_DOMAIN = testDomain;
+    const server = context.polly.server;
+    setupPollyMiddleware(server as unknown as PollyServer);
+  });
+
+  it("rejects when saleor domain is missing", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const domain = undefined;
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain,
+    });
+
+    const checkoutPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForCheckout },
+      __typename: "CalculateTaxes",
+    };
+    req.body = checkoutPayload;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it("rejects when saleor event is missing", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const event = undefined;
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: event,
+      domain: testDomain,
+    });
+
+    const checkoutPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForCheckout },
+      __typename: "CalculateTaxes",
+    };
+    req.body = [checkoutPayload];
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it.skip("rejects when saleor signature is empty", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const signature = undefined;
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain: testDomain,
+      signature,
+    });
+
+    const checkoutPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForCheckout },
+      __typename: "CalculateTaxes",
+    };
+    req.body = [checkoutPayload];
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it("rejects when saleor signature is incorrect", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const checkoutPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForCheckout },
+      __typename: "CalculateTaxes",
+    };
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(checkoutPayload),
+    });
+
+    const signature = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6.ABCD";
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain: testDomain,
+      signature,
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it("fetches taxes for checkout", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+
+    const checkoutPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForCheckout },
+      __typename: "CalculateTaxes",
+    };
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(checkoutPayload),
+    });
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+    expect(data.shipping_price_gross_amount).toBe("12.30");
+    expect(data.shipping_price_net_amount).toBe("10.00");
+    expect(data.shipping_tax_rate).toBe("23.00");
+    expect(data.lines.length).toBe(1);
+    expect(data.lines[0].total_gross_amount).toBe("60.00");
+    expect(data.lines[0].total_net_amount).toBe("48.78");
+    expect(data.lines[0].tax_rate).toBe("23.00");
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("propagates discounts over lines", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+    const checkoutPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForCheckout },
+      __typename: "CalculateTaxes",
+    };
+
+    checkoutPayload.taxBase.discounts = [
+      { amount: { amount: 2 } },
+      { amount: { amount: 1 } },
+    ];
+    const linePayload = { ...checkoutPayload.taxBase.lines[0] };
+    const secondLinePayload = {
+      ...linePayload,
+      totalPrice: { amount: 20 },
+      sourceLine: {
+        ...linePayload.sourceLine,
+        id: "Q2hlY2tvdXRMaW5lOjc=",
+      },
+    };
+    checkoutPayload.taxBase.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(checkoutPayload),
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    // amounts already include propagated discount
+    expect(data.shipping_price_gross_amount).toBe("11.90");
+    expect(data.shipping_price_net_amount).toBe("9.67");
+    expect(data.shipping_tax_rate).toBe("23.00");
+
+    expect(data.lines[0].total_gross_amount).toBe("58.05");
+    expect(data.lines[0].total_net_amount).toBe("47.20");
+    expect(data.lines[0].tax_rate).toBe("23.00");
+
+    expect(data.lines[1].total_gross_amount).toBe("19.35");
+    expect(data.lines[1].total_net_amount).toBe("15.73");
+    expect(data.lines[1].tax_rate).toBe("23.00");
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("with lines that have net prices", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+    const checkoutPayload = {
+      taxBase: {
+        ...dummyCalculateTaxesPayloadForCheckout,
+        pricesEnteredWithTax: false,
+      },
+      __typename: "CalculateTaxes",
+    };
+
+    checkoutPayload.taxBase.discounts = [
+      { amount: { amount: 2 } },
+      { amount: { amount: 1 } },
+    ];
+    const linePayload = { ...checkoutPayload.taxBase.lines[0] };
+    const secondLinePayload = {
+      ...linePayload,
+      totalPrice: { amount: 20 },
+      sourceLine: {
+        ...linePayload.sourceLine,
+        id: "Q2hlY2tvdXRMaW5lOjc=",
+      },
+      chargeTaxes: false,
+    };
+    checkoutPayload.taxBase.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(checkoutPayload),
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    expect(data.shipping_price_gross_amount).toBe("14.64");
+    expect(data.shipping_price_net_amount).toBe("11.90");
+    expect(data.shipping_tax_rate).toBe("23.00");
+
+    // amounts already include propagated discount
+    expect(data.lines[0].total_gross_amount).toBe("71.40");
+    expect(data.lines[0].total_net_amount).toBe("58.05");
+    expect(data.lines[0].tax_rate).toBe("23.00");
+
+    expect(data.lines[1].total_gross_amount).toBe("19.35");
+    expect(data.lines[1].total_net_amount).toBe("19.35");
+    expect(data.lines[1].tax_rate).toBe("0.00");
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+  it("with line that should not have calculated taxes", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+    const checkoutPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForCheckout },
+      __typename: "CalculateTaxes",
+    };
+
+    const linePayload = { ...checkoutPayload.taxBase.lines[0] };
+    const secondLinePayload = {
+      ...linePayload,
+      sourceLine: {
+        ...linePayload.sourceLine,
+        id: "Q2hlY2tvdXRMaW5lOjc=",
+      },
+      chargeTaxes: false,
+    };
+
+    checkoutPayload.taxBase.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(checkoutPayload),
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    expect(data.lines[0].total_gross_amount).toBe("60.00");
+    expect(data.lines[0].total_net_amount).toBe("48.78");
+    expect(data.lines[0].tax_rate).toBe("23.00");
+
+    expect(data.lines[1].total_gross_amount).toBe("60.00");
+    expect(data.lines[1].total_net_amount).toBe("60.00");
+    expect(data.lines[1].tax_rate).toBe("0.00");
+
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("with discounts and line that should not have calculated taxes", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+    const checkoutPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForCheckout },
+      __typename: "CalculateTaxes",
+    };
+    checkoutPayload.taxBase.discounts = [
+      { amount: { amount: 2 } },
+      { amount: { amount: 1 } },
+    ];
+    const linePayload = { ...checkoutPayload.taxBase.lines[0] };
+    const secondLinePayload = {
+      ...linePayload,
+      sourceLine: {
+        ...linePayload.sourceLine,
+        id: "Q2hlY2tvdXRMaW5lOjc=",
+      },
+      chargeTaxes: false,
+    };
+
+    checkoutPayload.taxBase.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(checkoutPayload),
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    // amounts already include propagated discount
+    expect(data.shipping_price_gross_amount).toBe("12.02");
+    expect(data.shipping_price_net_amount).toBe("9.77");
+    expect(data.shipping_tax_rate).toBe("23.00");
+
+    expect(data.lines[0].total_gross_amount).toBe("58.64");
+    expect(data.lines[0].total_net_amount).toBe("47.67");
+    expect(data.lines[0].tax_rate).toBe("23.00");
+
+    expect(data.lines[1].total_gross_amount).toBe("58.64");
+    expect(data.lines[1].total_net_amount).toBe("58.64");
+    expect(data.lines[1].tax_rate).toBe("0.00");
+
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("all lines with charge taxes set to false", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+    const checkoutPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForCheckout },
+      __typename: "CalculateTaxes",
+    };
+
+    const linePayload = {
+      ...checkoutPayload.taxBase.lines[0],
+      chargeTaxes: false,
+    };
+    const secondLinePayload = {
+      ...linePayload,
+      sourceLine: {
+        ...linePayload.sourceLine,
+        id: "Q2hlY2tvdXRMaW5lOjc=",
+      },
+    };
+
+    checkoutPayload.taxBase.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(checkoutPayload),
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    expect(data.lines[0].total_gross_amount).toBe("60.00");
+    expect(data.lines[0].total_net_amount).toBe("60.00");
+    expect(data.lines[0].tax_rate).toBe("0.00");
+
+    expect(data.lines[1].total_gross_amount).toBe("60.00");
+    expect(data.lines[1].total_net_amount).toBe("60.00");
+    expect(data.lines[1].tax_rate).toBe("0.00");
+
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+});

--- a/__tests__/pages/webhooks/order-calculate-taxes.test.ts
+++ b/__tests__/pages/webhooks/order-calculate-taxes.test.ts
@@ -1,0 +1,536 @@
+/** @jest-environment setup-polly-jest/jest-environment-node */
+import { PollyServer } from "@pollyjs/core";
+import * as joseModule from "jose";
+import { NextApiRequest, NextApiResponse } from "next";
+import { ResponseTaxPayload } from "../../../backend/types";
+import toNextHandler from "../../../pages/api/webhooks/order-calculate-taxes";
+import { setupPollyMiddleware, setupRecording } from "../../pollySetup";
+import {
+  dummyCalculateTaxesPayloadForOrder,
+  dummyFetchTaxesResponse,
+  mockRequest,
+} from "../../utils";
+import Avatax from "ava-typescript";
+
+jest.mock("next/dist/compiled/raw-body/index.js", () => ({
+  __esModule: true,
+  default: jest.fn((_) => ({
+    toString: () => '{"dummy":12}',
+  })),
+}));
+
+const testDomain = "localhost:8000";
+
+describe("api/webhooks/order-calculate-taxes", () => {
+  const context = setupRecording();
+  beforeEach(() => {
+    process.env.SALEOR_DOMAIN = testDomain;
+    const server = context.polly.server;
+    setupPollyMiddleware(server as unknown as PollyServer);
+  });
+
+  it("rejects when saleor domain is missing", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const domain = undefined;
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_calculate_taxes",
+      domain,
+    });
+
+    const orderPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForOrder },
+      __typename: "CalculateTaxes",
+    };
+    req.body = orderPayload;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it("rejects when saleor event is missing", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const event = undefined;
+    const { req, res } = mockRequest({
+      method: "POST",
+      event,
+      domain: testDomain,
+    });
+
+    const orderPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForOrder },
+      __typename: "CalculateTaxes",
+    };
+    req.body = orderPayload;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it.skip("rejects when saleor signature is empty", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const signature = undefined;
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_calculate_taxes",
+      domain: testDomain,
+      signature,
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it("rejects when saleor signature is incorrect", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const orderPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForOrder },
+      __typename: "CalculateTaxes",
+    };
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(orderPayload),
+    });
+
+    const signature = "incorrect-sig";
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_calculate_taxes",
+      domain: testDomain,
+      signature,
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it("fetches taxes for order", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+
+    const orderPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForOrder },
+      __typename: "CalculateTaxes",
+    };
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(orderPayload),
+    });
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    expect(data.shipping_price_gross_amount).toBe("12.30");
+    expect(data.shipping_price_net_amount).toBe("10.00");
+    expect(data.shipping_tax_rate).toBe("23.00");
+    expect(data.lines.length).toBe(1);
+    expect(data.lines[0].total_gross_amount).toBe("60.00");
+    expect(data.lines[0].total_net_amount).toBe("48.78");
+    expect(data.lines[0].tax_rate).toBe("23.00");
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("propagates discounts over lines", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+
+    const orderPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForOrder },
+      __typename: "CalculateTaxes",
+    };
+    orderPayload.taxBase.discounts = [
+      { amount: { amount: 2 } },
+      { amount: { amount: 1 } },
+    ];
+    const linePayload = { ...orderPayload.taxBase.lines[0] };
+    const secondLinePayload = {
+      ...linePayload,
+      totalPrice: { amount: 20 },
+      sourceLine: {
+        ...linePayload.sourceLine,
+        id: "Q2hlY2tvdXRMaW5lOjc=",
+      },
+    };
+    orderPayload.taxBase.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(orderPayload),
+    });
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    // amounts already include propagated discount
+    expect(data.shipping_price_gross_amount).toBe("11.90");
+    expect(data.shipping_price_net_amount).toBe("9.67");
+    expect(data.shipping_tax_rate).toBe("23.00");
+
+    expect(data.lines[0].total_gross_amount).toBe("58.05");
+    expect(data.lines[0].total_net_amount).toBe("47.20");
+    expect(data.lines[0].tax_rate).toBe("23.00");
+
+    expect(data.lines[1].total_gross_amount).toBe("19.35");
+    expect(data.lines[1].total_net_amount).toBe("15.73");
+    expect(data.lines[1].tax_rate).toBe("23.00");
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("with lines that have net prices", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+    const orderPayload = {
+      taxBase: {
+        ...dummyCalculateTaxesPayloadForOrder,
+        pricesEnteredWithTax: false,
+      },
+      __typename: "CalculateTaxes",
+    };
+
+    orderPayload.taxBase.discounts = [
+      { amount: { amount: 2 } },
+      { amount: { amount: 1 } },
+    ];
+    const linePayload = { ...orderPayload.taxBase.lines[0] };
+    const secondLinePayload = {
+      ...linePayload,
+      totalPrice: { amount: 20 },
+      sourceLine: {
+        ...linePayload.sourceLine,
+        id: "Q2hlY2tvdXRMaW5lOjc=",
+      },
+      chargeTaxes: false,
+    };
+    orderPayload.taxBase.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(orderPayload),
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    expect(data.shipping_price_gross_amount).toBe("14.64");
+    expect(data.shipping_price_net_amount).toBe("11.90");
+    expect(data.shipping_tax_rate).toBe("23.00");
+
+    // amounts already include propagated discount
+    expect(data.lines[0].total_gross_amount).toBe("71.40");
+    expect(data.lines[0].total_net_amount).toBe("58.05");
+    expect(data.lines[0].tax_rate).toBe("23.00");
+
+    expect(data.lines[1].total_gross_amount).toBe("19.35");
+    expect(data.lines[1].total_net_amount).toBe("19.35");
+    expect(data.lines[1].tax_rate).toBe("0.00");
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("with line that should not have calculated taxes", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+
+    const orderPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForOrder },
+      __typename: "CalculateTaxes",
+    };
+
+    const linePayload = { ...orderPayload.taxBase.lines[0] };
+    const secondLinePayload = {
+      ...linePayload,
+      sourceLine: {
+        ...linePayload.sourceLine,
+        id: "Q2hlY2tvdXRMaW5lOjc=",
+      },
+      chargeTaxes: false,
+    };
+    orderPayload.taxBase.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(orderPayload),
+    });
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    expect(data.lines[0].total_gross_amount).toBe("60.00");
+    expect(data.lines[0].total_net_amount).toBe("48.78");
+    expect(data.lines[0].tax_rate).toBe("23.00");
+
+    expect(data.lines[1].total_gross_amount).toBe("60.00");
+    expect(data.lines[1].total_net_amount).toBe("60.00");
+    expect(data.lines[1].tax_rate).toBe("0.00");
+
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("with discounts and line that should not have calculated taxes", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+
+    const orderPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForOrder },
+      __typename: "CalculateTaxes",
+    };
+    orderPayload.taxBase.discounts = [
+      { amount: { amount: 2 } },
+      { amount: { amount: 1 } },
+    ];
+    const linePayload = { ...orderPayload.taxBase.lines[0] };
+    const secondLinePayload = {
+      ...linePayload,
+      sourceLine: {
+        ...linePayload.sourceLine,
+        id: "Q2hlY2tvdXRMaW5lOjc=",
+      },
+      chargeTaxes: false,
+    };
+    orderPayload.taxBase.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(orderPayload),
+    });
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    // amounts already include propagated discount
+    expect(data.shipping_price_gross_amount).toBe("12.02");
+    expect(data.shipping_price_net_amount).toBe("9.77");
+    expect(data.shipping_tax_rate).toBe("23.00");
+
+    expect(data.lines[0].total_gross_amount).toBe("58.64");
+    expect(data.lines[0].total_net_amount).toBe("47.67");
+    expect(data.lines[0].tax_rate).toBe("23.00");
+
+    expect(data.lines[1].total_gross_amount).toBe("58.64");
+    expect(data.lines[1].total_net_amount).toBe("58.64");
+    expect(data.lines[1].tax_rate).toBe("0.00");
+
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("all lines with charge taxes set to false", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+
+    const orderPayload = {
+      taxBase: { ...dummyCalculateTaxesPayloadForOrder },
+      __typename: "CalculateTaxes",
+    };
+
+    const linePayload = {
+      ...orderPayload.taxBase.lines[0],
+      chargeTaxes: false,
+    };
+    const secondLinePayload = {
+      ...linePayload,
+      id: "T3JkZXJMaW5lOjc=",
+      charge_taxes: false,
+    };
+    orderPayload.taxBase.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(orderPayload),
+    });
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    expect(data.lines[0].total_gross_amount).toBe("60.00");
+    expect(data.lines[0].total_net_amount).toBe("60.00");
+    expect(data.lines[0].tax_rate).toBe("0.00");
+
+    expect(data.lines[1].total_gross_amount).toBe("60.00");
+    expect(data.lines[1].total_net_amount).toBe("60.00");
+    expect(data.lines[1].tax_rate).toBe("0.00");
+
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+});

--- a/__tests__/pages/webhooks/order-created.test.ts
+++ b/__tests__/pages/webhooks/order-created.test.ts
@@ -1,0 +1,182 @@
+/** @jest-environment setup-polly-jest/jest-environment-node */
+
+import { PollyServer } from "@pollyjs/core";
+import * as joseModule from "jose";
+import { NextApiRequest, NextApiResponse } from "next";
+import toNextHandler from "../../../pages/api/webhooks/order-created";
+import { setupPollyMiddleware, setupRecording } from "../../pollySetup";
+import {
+  dummyOrderCreatedPayload,
+  mockRequest,
+  dummyFetchTaxesResponse,
+} from "../../utils";
+import Avatax from "ava-typescript";
+
+jest.mock("next/dist/compiled/raw-body/index.js", () => ({
+  __esModule: true,
+  default: jest.fn((_) => ({
+    toString: () => '{"dummy":12}',
+  })),
+}));
+
+const testDomain = "localhost:8000";
+describe("api/webhooks/order-created", () => {
+  const context = setupRecording();
+  beforeEach(() => {
+    process.env.SALEOR_DOMAIN = testDomain;
+    const server = context.polly.server;
+    setupPollyMiddleware(server as unknown as PollyServer);
+  });
+
+  it("rejects when saleor domain is missing", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const domain = undefined;
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_created",
+      domain,
+    });
+
+    const orderPayload = dummyOrderCreatedPayload;
+    req.body = orderPayload;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it("rejects when saleor event is missing", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const event = undefined;
+    const { req, res } = mockRequest({
+      method: "POST",
+      event,
+      domain: testDomain,
+    });
+
+    const orderPayload = dummyOrderCreatedPayload;
+    req.body = orderPayload;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it.skip("rejects when saleor signature is empty", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const signature = undefined;
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_created",
+      domain: testDomain,
+      signature,
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it("rejects when saleor signature is incorrect", async () => {
+    const mockedCreateTransaction = jest
+      .spyOn(Avatax.prototype, "createTransaction")
+      .mockResolvedValue(dummyFetchTaxesResponse);
+
+    const orderPayload = dummyOrderCreatedPayload;
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(orderPayload),
+    });
+
+    const signature = "incorrect-sig";
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_created",
+      domain: testDomain,
+      signature,
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedCreateTransaction).not.toHaveBeenCalled();
+
+    mockedCreateTransaction.mockRestore();
+  });
+
+  it("creates transaction on Avatax side for new order", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "order_created",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
+      );
+
+    const orderPayload = dummyOrderCreatedPayload;
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify(orderPayload),
+    });
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await toNextHandler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+});

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/all-lines-with-charge-taxes-set-to-false_1242416524/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/all-lines-with-charge-taxes-set-to-false_1242416524/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/checkout-calculate-taxes/all lines with charge taxes set to false",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:30 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:30.657Z",
+        "time": 187,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 187
+        }
+      },
+      {
+        "_id": "3029b00d201d0e1781383ef17860a8e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1061,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1061"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 433,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T07:10:25.385Z\",\"customerCode\":\"0\",\"discount\":0,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"S\",\"taxIncluded\":true,\"discounted\":false,\"taxOverride\":{\"type\":\"taxAmount\",\"taxAmount\":0,\"reason\":\"Charge taxes for this product are turned off.\"}},{\"number\":\"1\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"S\",\"taxIncluded\":true,\"discounted\":false,\"taxOverride\":{\"type\":\"taxAmount\",\"taxAmount\":0,\"reason\":\"Charge taxes for this product are turned off.\"}},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":true,\"discounted\":false}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 5415,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 5415,
+            "text": "{\"id\":0,\"code\":\"4a373e1b-34df-44ea-a320-2f5bf35827f0\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":130.0,\"totalExempt\":120.0,\"totalDiscount\":0.0,\"totalTax\":2.3,\"totalTaxable\":10.0,\"totalTaxCalculated\":29.9,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:30.969406Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"S\",\"discountAmount\":0.0,\"exemptAmount\":60.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":false,\"itemCode\":\"328223580\",\"lineAmount\":60.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":0.0,\"taxableAmount\":0.0,\"taxCalculated\":13.8,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxOverrideType\":\"TaxAmount\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"Charge taxes for this product are turned off.\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":60.0,\"rate\":0.230000,\"tax\":0.0,\"taxableAmount\":0.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":13.8,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":0.0,\"reportingNonTaxableUnits\":60.0,\"reportingExemptUnits\":0.0,\"reportingTax\":0.0,\"reportingTaxCalculated\":13.8,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"S\",\"discountAmount\":0.0,\"exemptAmount\":60.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":false,\"itemCode\":\"328223580\",\"lineAmount\":60.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":0.0,\"taxableAmount\":0.0,\"taxCalculated\":13.8,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxOverrideType\":\"TaxAmount\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"Charge taxes for this product are turned off.\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":60.0,\"rate\":0.230000,\"tax\":0.0,\"taxableAmount\":0.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":13.8,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":0.0,\"reportingNonTaxableUnits\":60.0,\"reportingExemptUnits\":0.0,\"reportingTax\":0.0,\"reportingTaxCalculated\":13.8,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"2\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":10.0000,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.3,\"taxableAmount\":10.0,\"taxCalculated\":2.3,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.3,\"taxableAmount\":10.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.3,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":10.0,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.3,\"reportingTaxCalculated\":2.3,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":10.0,\"rate\":0.230000,\"tax\":2.3,\"taxCalculated\":29.9,\"nonTaxable\":120.0,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0193954"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "6c4d77fc-d615-43ca-8813-31e3b889c665"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "6c4d77fc-d615-43ca-8813-31e3b889c665"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:30.849Z",
+        "time": 614,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 614
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/fetches-taxes-for-checkout_4167522303/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/fetches-taxes-for-checkout_4167522303/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/checkout-calculate-taxes/fetches taxes for checkout",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:25 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:25.709Z",
+        "time": 288,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 288
+        }
+      },
+      {
+        "_id": "0c3d0f3d56a53d200424e2121f2c3d14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 709,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "709"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 432,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T07:10:25.385Z\",\"customerCode\":\"0\",\"discount\":0,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"S\",\"taxIncluded\":true,\"discounted\":false},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":true,\"discounted\":false}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 3984,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3984,
+            "text": "{\"id\":0,\"code\":\"80bf1386-02c2-4333-ade3-5301c84eb2f4\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":58.78,\"totalExempt\":0.0,\"totalDiscount\":0.0,\"totalTax\":13.52,\"totalTaxable\":58.78,\"totalTaxCalculated\":13.52,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:26.534844Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"S\",\"discountAmount\":0.0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":48.7800,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":11.22,\"taxableAmount\":48.78,\"taxCalculated\":11.22,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":11.22,\"taxableAmount\":48.78,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":11.22,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":48.78,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":11.22,\"reportingTaxCalculated\":11.22,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":10.0000,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.3,\"taxableAmount\":10.0,\"taxCalculated\":2.3,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.3,\"taxableAmount\":10.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.3,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":10.0,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.3,\"reportingTaxCalculated\":2.3,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":58.78,\"rate\":0.230000,\"tax\":13.52,\"taxCalculated\":13.52,\"nonTaxable\":0.0,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0167928"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "46a025d8-9a73-4c5f-869b-acbadc982bdc"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "46a025d8-9a73-4c5f-869b-acbadc982bdc"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:26.011Z",
+        "time": 920,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 920
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/propagates-discounts-over-lines_2729315478/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/propagates-discounts-over-lines_2729315478/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/checkout-calculate-taxes/propagates discounts over lines",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:27 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:26.946Z",
+        "time": 191,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 191
+        }
+      },
+      {
+        "_id": "5f34925dd18291a11fd430d9542349c7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 846,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "846"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 432,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T07:10:25.385Z\",\"customerCode\":\"0\",\"discount\":3,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"S\",\"taxIncluded\":true,\"discounted\":true},{\"number\":\"1\",\"quantity\":3,\"amount\":20,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"S\",\"taxIncluded\":true,\"discounted\":true},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":true,\"discounted\":true}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 5199,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 5199,
+            "text": "{\"id\":0,\"code\":\"7168a2b8-fed8-4b7c-b096-c95546c76c48\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":75.6,\"totalExempt\":0.0,\"totalDiscount\":3.0,\"totalTax\":16.7,\"totalTaxable\":72.6,\"totalTaxCalculated\":16.7,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:27.4868004Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"S\",\"discountAmount\":1.95,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":49.1500,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":10.85,\"taxableAmount\":47.2,\"taxCalculated\":10.85,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":10.85,\"taxableAmount\":47.2,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":10.85,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":47.2,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":10.85,\"reportingTaxCalculated\":10.85,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"S\",\"discountAmount\":0.65,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":16.3800,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":3.62,\"taxableAmount\":15.73,\"taxCalculated\":3.62,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":3.62,\"taxableAmount\":15.73,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":3.62,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":15.73,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":3.62,\"reportingTaxCalculated\":3.62,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"2\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.4,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":10.0700,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.23,\"taxableAmount\":9.67,\"taxCalculated\":2.23,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.23,\"taxableAmount\":9.67,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.23,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":9.67,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.23,\"reportingTaxCalculated\":2.23,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":72.60,\"rate\":0.230000,\"tax\":16.70,\"taxCalculated\":16.70,\"nonTaxable\":0.0,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:27 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0278081"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "142cd7cc-b8b7-45b7-b5f9-c5f5e2fc15e2"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "142cd7cc-b8b7-45b7-b5f9-c5f5e2fc15e2"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:27.142Z",
+        "time": 1018,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1018
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/with-discounts-and-line-that-should-not-have-calculated-taxes_1077603000/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/with-discounts-and-line-that-should-not-have-calculated-taxes_1077603000/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/checkout-calculate-taxes/with discounts and line that should not have calculated taxes",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:30 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:29.836Z",
+        "time": 185,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 185
+        }
+      },
+      {
+        "_id": "6a19f0db2817fda3d9432efb8c43d718",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 952,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "952"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 432,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T07:10:25.385Z\",\"customerCode\":\"0\",\"discount\":3,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"S\",\"taxIncluded\":true,\"discounted\":true},{\"number\":\"1\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"S\",\"taxIncluded\":true,\"discounted\":true,\"taxOverride\":{\"type\":\"taxAmount\",\"taxAmount\":0,\"reason\":\"Charge taxes for this product are turned off.\"}},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":true,\"discounted\":true}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 5332,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 5332,
+            "text": "{\"id\":0,\"code\":\"69ef2016-01fc-4d6a-b0e3-9236f68d6387\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":119.08,\"totalExempt\":58.64,\"totalDiscount\":3.0,\"totalTax\":13.22,\"totalTaxable\":57.44,\"totalTaxCalculated\":26.71,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:30.1510575Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"S\",\"discountAmount\":1.36,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":49.0300,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":10.97,\"taxableAmount\":47.67,\"taxCalculated\":10.97,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":10.97,\"taxableAmount\":47.67,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":10.97,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":47.67,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":10.97,\"reportingTaxCalculated\":10.97,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"S\",\"discountAmount\":1.36,\"exemptAmount\":58.64,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":false,\"itemCode\":\"328223580\",\"lineAmount\":60.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":0.0,\"taxableAmount\":0.0,\"taxCalculated\":13.49,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxOverrideType\":\"TaxAmount\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"Charge taxes for this product are turned off.\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":58.64,\"rate\":0.230000,\"tax\":0.0,\"taxableAmount\":0.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":13.49,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":0.0,\"reportingNonTaxableUnits\":58.64,\"reportingExemptUnits\":0.0,\"reportingTax\":0.0,\"reportingTaxCalculated\":13.49,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"2\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.28,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":10.0500,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.25,\"taxableAmount\":9.77,\"taxCalculated\":2.25,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.25,\"taxableAmount\":9.77,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.25,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":9.77,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.25,\"reportingTaxCalculated\":2.25,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":57.44,\"rate\":0.230000,\"tax\":13.22,\"taxCalculated\":26.71,\"nonTaxable\":58.64,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0186386"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "16bb258b-195a-4679-9da2-13e9f9db3632"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "16bb258b-195a-4679-9da2-13e9f9db3632"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:30.026Z",
+        "time": 621,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 621
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/with-line-that-should-not-have-calculated-taxes_2581615363/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/with-line-that-should-not-have-calculated-taxes_2581615363/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/checkout-calculate-taxes/with line that should not have calculated taxes",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:29 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:29.003Z",
+        "time": 191,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 191
+        }
+      },
+      {
+        "_id": "0be34bc67e0ba9119d2a95b817ac129d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 955,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "955"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 432,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T07:10:25.385Z\",\"customerCode\":\"0\",\"discount\":0,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"S\",\"taxIncluded\":true,\"discounted\":false},{\"number\":\"1\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"S\",\"taxIncluded\":true,\"discounted\":false,\"taxOverride\":{\"type\":\"taxAmount\",\"taxAmount\":0,\"reason\":\"Charge taxes for this product are turned off.\"}},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":true,\"discounted\":false}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 5315,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 5315,
+            "text": "{\"id\":0,\"code\":\"b3e10fdd-100d-4c97-a9d4-ea2b4e687db2\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":118.78,\"totalExempt\":60.0,\"totalDiscount\":0.0,\"totalTax\":13.52,\"totalTaxable\":58.78,\"totalTaxCalculated\":27.32,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:29.3315853Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"S\",\"discountAmount\":0.0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":48.7800,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":11.22,\"taxableAmount\":48.78,\"taxCalculated\":11.22,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":11.22,\"taxableAmount\":48.78,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":11.22,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":48.78,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":11.22,\"reportingTaxCalculated\":11.22,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"S\",\"discountAmount\":0.0,\"exemptAmount\":60.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":false,\"itemCode\":\"328223580\",\"lineAmount\":60.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":0.0,\"taxableAmount\":0.0,\"taxCalculated\":13.8,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxOverrideType\":\"TaxAmount\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"Charge taxes for this product are turned off.\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":60.0,\"rate\":0.230000,\"tax\":0.0,\"taxableAmount\":0.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":13.8,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":0.0,\"reportingNonTaxableUnits\":60.0,\"reportingExemptUnits\":0.0,\"reportingTax\":0.0,\"reportingTaxCalculated\":13.8,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"2\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":10.0000,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.3,\"taxableAmount\":10.0,\"taxCalculated\":2.3,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.3,\"taxableAmount\":10.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.3,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":10.0,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.3,\"reportingTaxCalculated\":2.3,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":58.78,\"rate\":0.230000,\"tax\":13.52,\"taxCalculated\":27.32,\"nonTaxable\":60.0,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0208392"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "ffc14f71-fd07-4745-b3c4-dfb2b0a879b4"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "ffc14f71-fd07-4745-b3c4-dfb2b0a879b4"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:29.199Z",
+        "time": 627,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 627
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/with-lines-that-have-net-prices_2092412690/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/with-lines-that-have-net-prices_2092412690/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/checkout-calculate-taxes/with lines that have net prices",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:28 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:28.171Z",
+        "time": 193,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 193
+        }
+      },
+      {
+        "_id": "4dd16a02f94b88effd604113656e3088",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 955,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "955"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 432,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T07:10:25.385Z\",\"customerCode\":\"0\",\"discount\":3,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"S\",\"taxIncluded\":false,\"discounted\":true},{\"number\":\"1\",\"quantity\":3,\"amount\":20,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"S\",\"taxIncluded\":false,\"discounted\":true,\"taxOverride\":{\"type\":\"taxAmount\",\"taxAmount\":0,\"reason\":\"Charge taxes for this product are turned off.\"}},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":false,\"discounted\":true}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 5323,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 5323,
+            "text": "{\"id\":0,\"code\":\"3d396907-bce5-4c89-afd0-b560c23880e4\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":92.3,\"totalExempt\":19.35,\"totalDiscount\":3.0,\"totalTax\":16.09,\"totalTaxable\":69.95,\"totalTaxCalculated\":20.54,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:28.4973491Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"S\",\"discountAmount\":1.95,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":60.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":13.35,\"taxableAmount\":58.05,\"taxCalculated\":13.35,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":false,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":13.35,\"taxableAmount\":58.05,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":13.35,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":58.05,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":13.35,\"reportingTaxCalculated\":13.35,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"S\",\"discountAmount\":0.65,\"exemptAmount\":19.35,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":false,\"itemCode\":\"328223580\",\"lineAmount\":20.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":0.0,\"taxableAmount\":0.0,\"taxCalculated\":4.45,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxOverrideType\":\"TaxAmount\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"Charge taxes for this product are turned off.\",\"taxIncluded\":false,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":19.35,\"rate\":0.230000,\"tax\":0.0,\"taxableAmount\":0.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":4.45,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":0.0,\"reportingNonTaxableUnits\":19.35,\"reportingExemptUnits\":0.0,\"reportingTax\":0.0,\"reportingTaxCalculated\":4.45,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"2\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.4,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":12.3,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.74,\"taxableAmount\":11.9,\"taxCalculated\":2.74,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":false,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.74,\"taxableAmount\":11.9,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.74,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":11.9,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.74,\"reportingTaxCalculated\":2.74,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":69.95,\"rate\":0.230000,\"tax\":16.09,\"taxCalculated\":20.54,\"nonTaxable\":19.35,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0198098"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "4dcb4c34-a001-4ea3-ba2c-375e65907051"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "4dcb4c34-a001-4ea3-ba2c-375e65907051"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:28.368Z",
+        "time": 624,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 624
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/all-lines-with-charge-taxes-set-to-false_1242416524/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/all-lines-with-charge-taxes-set-to-false_1242416524/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/order-calculate-taxes/all lines with charge taxes set to false",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:30 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:30.664Z",
+        "time": 183,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 183
+        }
+      },
+      {
+        "_id": "399c616b85311c8f099de12185ed52e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1085,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1085"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 433,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T10:26:05.832Z\",\"customerCode\":\"0\",\"discount\":0,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"Monospace Tee\",\"taxIncluded\":true,\"discounted\":false,\"taxOverride\":{\"type\":\"taxAmount\",\"taxAmount\":0,\"reason\":\"Charge taxes for this product are turned off.\"}},{\"number\":\"1\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"Monospace Tee\",\"taxIncluded\":true,\"discounted\":false,\"taxOverride\":{\"type\":\"taxAmount\",\"taxAmount\":0,\"reason\":\"Charge taxes for this product are turned off.\"}},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":true,\"discounted\":false}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 5440,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 5440,
+            "text": "{\"id\":0,\"code\":\"2696c288-ad95-4cc3-bfdc-a3d7de346bb4\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":130.0,\"totalExempt\":120.0,\"totalDiscount\":0.0,\"totalTax\":2.3,\"totalTaxable\":10.0,\"totalTaxCalculated\":29.9,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:30.8299968Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Monospace Tee\",\"discountAmount\":0.0,\"exemptAmount\":60.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":false,\"itemCode\":\"328223580\",\"lineAmount\":60.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":0.0,\"taxableAmount\":0.0,\"taxCalculated\":13.8,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxOverrideType\":\"TaxAmount\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"Charge taxes for this product are turned off.\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":60.0,\"rate\":0.230000,\"tax\":0.0,\"taxableAmount\":0.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":13.8,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":0.0,\"reportingNonTaxableUnits\":60.0,\"reportingExemptUnits\":0.0,\"reportingTax\":0.0,\"reportingTaxCalculated\":13.8,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Monospace Tee\",\"discountAmount\":0.0,\"exemptAmount\":60.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":false,\"itemCode\":\"328223580\",\"lineAmount\":60.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":0.0,\"taxableAmount\":0.0,\"taxCalculated\":13.8,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxOverrideType\":\"TaxAmount\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"Charge taxes for this product are turned off.\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":60.0,\"rate\":0.230000,\"tax\":0.0,\"taxableAmount\":0.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":13.8,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":0.0,\"reportingNonTaxableUnits\":60.0,\"reportingExemptUnits\":0.0,\"reportingTax\":0.0,\"reportingTaxCalculated\":13.8,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"2\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":10.0000,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.3,\"taxableAmount\":10.0,\"taxCalculated\":2.3,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.3,\"taxableAmount\":10.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.3,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":10.0,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.3,\"reportingTaxCalculated\":2.3,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":10.0,\"rate\":0.230000,\"tax\":2.3,\"taxCalculated\":29.9,\"nonTaxable\":120.0,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0200576"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "7140fd15-8638-4af9-9a06-5477b327d9b2"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "7140fd15-8638-4af9-9a06-5477b327d9b2"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:30.852Z",
+        "time": 624,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 624
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/fetches-taxes-for-order_2379910021/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/fetches-taxes-for-order_2379910021/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/order-calculate-taxes/fetches taxes for order",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:26 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:25.727Z",
+        "time": 281,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 281
+        }
+      },
+      {
+        "_id": "58ce333a2b56a5076b3cce7aae01c19c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 721,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "721"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 432,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T10:26:05.832Z\",\"customerCode\":\"0\",\"discount\":0,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"Monospace Tee\",\"taxIncluded\":true,\"discounted\":false},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":true,\"discounted\":false}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 3997,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3997,
+            "text": "{\"id\":0,\"code\":\"300256e4-73bd-422a-b6b5-2a37ff0a7682\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":58.78,\"totalExempt\":0.0,\"totalDiscount\":0.0,\"totalTax\":13.52,\"totalTaxable\":58.78,\"totalTaxCalculated\":13.52,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:26.2164028Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Monospace Tee\",\"discountAmount\":0.0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":48.7800,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":11.22,\"taxableAmount\":48.78,\"taxCalculated\":11.22,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":11.22,\"taxableAmount\":48.78,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":11.22,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":48.78,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":11.22,\"reportingTaxCalculated\":11.22,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":10.0000,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.3,\"taxableAmount\":10.0,\"taxCalculated\":2.3,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.3,\"taxableAmount\":10.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.3,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":10.0,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.3,\"reportingTaxCalculated\":2.3,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":58.78,\"rate\":0.230000,\"tax\":13.52,\"taxCalculated\":13.52,\"nonTaxable\":0.0,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0162902"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "4b097a78-5d7a-40c8-82e4-91a08b96a672"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "4b097a78-5d7a-40c8-82e4-91a08b96a672"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:26.022Z",
+        "time": 910,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 910
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/propagates-discounts-over-lines_2729315478/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/propagates-discounts-over-lines_2729315478/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/order-calculate-taxes/propagates discounts over lines",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:27 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:26.947Z",
+        "time": 193,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 193
+        }
+      },
+      {
+        "_id": "ed77d6371d9f20345075423cd07fdf1c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 870,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "870"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 432,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T10:26:05.832Z\",\"customerCode\":\"0\",\"discount\":3,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"Monospace Tee\",\"taxIncluded\":true,\"discounted\":true},{\"number\":\"1\",\"quantity\":3,\"amount\":20,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"Monospace Tee\",\"taxIncluded\":true,\"discounted\":true},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":true,\"discounted\":true}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 5223,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 5223,
+            "text": "{\"id\":0,\"code\":\"090e926b-0a38-4156-aaa0-c070bf6a8234\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":75.6,\"totalExempt\":0.0,\"totalDiscount\":3.0,\"totalTax\":16.7,\"totalTaxable\":72.6,\"totalTaxCalculated\":16.7,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:27.3252133Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Monospace Tee\",\"discountAmount\":1.95,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":49.1500,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":10.85,\"taxableAmount\":47.2,\"taxCalculated\":10.85,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":10.85,\"taxableAmount\":47.2,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":10.85,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":47.2,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":10.85,\"reportingTaxCalculated\":10.85,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Monospace Tee\",\"discountAmount\":0.65,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":16.3800,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":3.62,\"taxableAmount\":15.73,\"taxCalculated\":3.62,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":3.62,\"taxableAmount\":15.73,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":3.62,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":15.73,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":3.62,\"reportingTaxCalculated\":3.62,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"2\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.4,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":10.0700,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.23,\"taxableAmount\":9.67,\"taxCalculated\":2.23,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.23,\"taxableAmount\":9.67,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.23,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":9.67,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.23,\"reportingTaxCalculated\":2.23,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":72.60,\"rate\":0.230000,\"tax\":16.70,\"taxCalculated\":16.70,\"nonTaxable\":0.0,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:27 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0210942"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "04975fcf-3c62-492c-a5e5-524f60461986"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "04975fcf-3c62-492c-a5e5-524f60461986"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:27.146Z",
+        "time": 1014,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1014
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/with-discounts-and-line-that-should-not-have-calculated-taxes_1077603000/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/with-discounts-and-line-that-should-not-have-calculated-taxes_1077603000/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/order-calculate-taxes/with discounts and line that should not have calculated taxes",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:30 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:29.839Z",
+        "time": 185,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 185
+        }
+      },
+      {
+        "_id": "d903c0a3875a7b2513ba1ed33c311944",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 976,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "976"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 432,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T10:26:05.832Z\",\"customerCode\":\"0\",\"discount\":3,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"Monospace Tee\",\"taxIncluded\":true,\"discounted\":true},{\"number\":\"1\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"Monospace Tee\",\"taxIncluded\":true,\"discounted\":true,\"taxOverride\":{\"type\":\"taxAmount\",\"taxAmount\":0,\"reason\":\"Charge taxes for this product are turned off.\"}},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":true,\"discounted\":true}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 5356,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 5356,
+            "text": "{\"id\":0,\"code\":\"933cdb5c-8171-44f0-a499-b348657394c0\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":119.08,\"totalExempt\":58.64,\"totalDiscount\":3.0,\"totalTax\":13.22,\"totalTaxable\":57.44,\"totalTaxCalculated\":26.71,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:30.3303784Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Monospace Tee\",\"discountAmount\":1.36,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":49.0300,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":10.97,\"taxableAmount\":47.67,\"taxCalculated\":10.97,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":10.97,\"taxableAmount\":47.67,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":10.97,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":47.67,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":10.97,\"reportingTaxCalculated\":10.97,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Monospace Tee\",\"discountAmount\":1.36,\"exemptAmount\":58.64,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":false,\"itemCode\":\"328223580\",\"lineAmount\":60.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":0.0,\"taxableAmount\":0.0,\"taxCalculated\":13.49,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxOverrideType\":\"TaxAmount\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"Charge taxes for this product are turned off.\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":58.64,\"rate\":0.230000,\"tax\":0.0,\"taxableAmount\":0.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":13.49,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":0.0,\"reportingNonTaxableUnits\":58.64,\"reportingExemptUnits\":0.0,\"reportingTax\":0.0,\"reportingTaxCalculated\":13.49,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"2\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.28,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":10.0500,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.25,\"taxableAmount\":9.77,\"taxCalculated\":2.25,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.25,\"taxableAmount\":9.77,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.25,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":9.77,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.25,\"reportingTaxCalculated\":2.25,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":57.44,\"rate\":0.230000,\"tax\":13.22,\"taxCalculated\":26.71,\"nonTaxable\":58.64,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0201587"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "fce15be2-8c54-4b4d-b49f-99a6a1b39332"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "fce15be2-8c54-4b4d-b49f-99a6a1b39332"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:30.028Z",
+        "time": 626,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 626
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/with-line-that-should-not-have-calculated-taxes_2581615363/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/with-line-that-should-not-have-calculated-taxes_2581615363/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/order-calculate-taxes/with line that should not have calculated taxes",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:29 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:29.001Z",
+        "time": 194,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 194
+        }
+      },
+      {
+        "_id": "f6685bba341120e460c663499b61fb3e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 979,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "979"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 432,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T10:26:05.832Z\",\"customerCode\":\"0\",\"discount\":0,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"Monospace Tee\",\"taxIncluded\":true,\"discounted\":false},{\"number\":\"1\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"Monospace Tee\",\"taxIncluded\":true,\"discounted\":false,\"taxOverride\":{\"type\":\"taxAmount\",\"taxAmount\":0,\"reason\":\"Charge taxes for this product are turned off.\"}},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":true,\"discounted\":false}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 5339,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 5339,
+            "text": "{\"id\":0,\"code\":\"4d3cfd9b-d14a-4212-b5dc-e40ffcc7f7e8\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":118.78,\"totalExempt\":60.0,\"totalDiscount\":0.0,\"totalTax\":13.52,\"totalTaxable\":58.78,\"totalTaxCalculated\":27.32,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:29.6359551Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Monospace Tee\",\"discountAmount\":0.0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":48.7800,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":11.22,\"taxableAmount\":48.78,\"taxCalculated\":11.22,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":11.22,\"taxableAmount\":48.78,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":11.22,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":48.78,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":11.22,\"reportingTaxCalculated\":11.22,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Monospace Tee\",\"discountAmount\":0.0,\"exemptAmount\":60.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":false,\"itemCode\":\"328223580\",\"lineAmount\":60.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":0.0,\"taxableAmount\":0.0,\"taxCalculated\":13.8,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxOverrideType\":\"TaxAmount\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"Charge taxes for this product are turned off.\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":60.0,\"rate\":0.230000,\"tax\":0.0,\"taxableAmount\":0.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":13.8,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":0.0,\"reportingNonTaxableUnits\":60.0,\"reportingExemptUnits\":0.0,\"reportingTax\":0.0,\"reportingTaxCalculated\":13.8,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"2\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":10.0000,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.3,\"taxableAmount\":10.0,\"taxCalculated\":2.3,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":true,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.3,\"taxableAmount\":10.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.3,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":10.0,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.3,\"reportingTaxCalculated\":2.3,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":58.78,\"rate\":0.230000,\"tax\":13.52,\"taxCalculated\":27.32,\"nonTaxable\":60.0,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0184895"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "2c69cee7-ce39-4b9f-8faf-956bf8399322"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "2c69cee7-ce39-4b9f-8faf-956bf8399322"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:29.201Z",
+        "time": 629,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 629
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/with-lines-that-have-net-prices_2092412690/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/with-lines-that-have-net-prices_2092412690/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/order-calculate-taxes/with lines that have net prices",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:28 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:28.171Z",
+        "time": 190,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 190
+        }
+      },
+      {
+        "_id": "a896ea7157ff1dfbbbc8106010c90ae4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 979,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "979"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 432,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":0,\"companyCode\":\"DEFAULT\",\"code\":\"\",\"date\":\"2022-08-31T10:26:05.832Z\",\"customerCode\":\"0\",\"discount\":3,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":3,\"amount\":60,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"Monospace Tee\",\"taxIncluded\":false,\"discounted\":true},{\"number\":\"1\",\"quantity\":3,\"amount\":20,\"itemCode\":\"328223580\",\"taxCode\":\"O9999999\",\"description\":\"Monospace Tee\",\"taxIncluded\":false,\"discounted\":true,\"taxOverride\":{\"type\":\"taxAmount\",\"taxAmount\":0,\"reason\":\"Charge taxes for this product are turned off.\"}},{\"number\":\"\",\"quantity\":1,\"amount\":12.3,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":false,\"discounted\":true}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 5347,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 5347,
+            "text": "{\"id\":0,\"code\":\"8cb5f329-2355-462f-aed1-2f37ae0ba109\",\"companyId\":7799660,\"date\":\"2022-08-31\",\"paymentDate\":\"2022-08-31\",\"status\":\"Temporary\",\"type\":\"SalesOrder\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"totalAmount\":92.3,\"totalExempt\":19.35,\"totalDiscount\":3.0,\"totalTax\":16.09,\"totalTaxable\":69.95,\"totalTaxCalculated\":20.54,\"adjustmentReason\":\"NotAdjusted\",\"locked\":false,\"version\":1,\"exchangeRateEffectiveDate\":\"2022-08-31\",\"exchangeRate\":1.0,\"modifiedDate\":\"2022-08-31T12:12:28.3433674Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-31\",\"lines\":[{\"id\":0,\"transactionId\":0,\"lineNumber\":\"0\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Monospace Tee\",\"discountAmount\":1.95,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"328223580\",\"lineAmount\":60.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":13.35,\"taxableAmount\":58.05,\"taxCalculated\":13.35,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxIncluded\":false,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":13.35,\"taxableAmount\":58.05,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":13.35,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":58.05,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":13.35,\"reportingTaxCalculated\":13.35,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"1\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Monospace Tee\",\"discountAmount\":0.65,\"exemptAmount\":19.35,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":false,\"itemCode\":\"328223580\",\"lineAmount\":20.0,\"quantity\":3.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":0.0,\"taxableAmount\":0.0,\"taxCalculated\":4.45,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-31\",\"taxOverrideType\":\"TaxAmount\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"Charge taxes for this product are turned off.\",\"taxIncluded\":false,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":19.35,\"rate\":0.230000,\"tax\":0.0,\"taxableAmount\":0.0,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":4.45,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":0.0,\"reportingNonTaxableUnits\":19.35,\"reportingExemptUnits\":0.0,\"reportingTax\":0.0,\"reportingTaxCalculated\":4.45,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":0,\"transactionId\":0,\"lineNumber\":\"2\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"discountAmount\":0.4,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"itemCode\":\"Shipping\",\"lineAmount\":12.3,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-31\",\"tax\":2.74,\"taxableAmount\":11.9,\"taxCalculated\":2.74,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-31\",\"taxIncluded\":false,\"details\":[{\"id\":0,\"transactionLineId\":0,\"transactionId\":0,\"country\":\"PL\",\"region\":\"PL\",\"exemptAmount\":0.0,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0,\"rate\":0.230000,\"tax\":2.74,\"taxableAmount\":11.9,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxCalculated\":2.74,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":11.9,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.74,\"reportingTaxCalculated\":2.74,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 777\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"},{\"id\":0,\"transactionId\":0,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102,\"latitude\":\"\",\"longitude\":\"\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":69.95,\"rate\":0.230000,\"tax\":16.09,\"taxCalculated\":20.54,\"nonTaxable\":19.35,\"exemption\":0.0}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0206694"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "41e72376-6e0a-45fc-a2c7-06e7455371f4"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "41e72376-6e0a-45fc-a2c7-06e7455371f4"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/0",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:28.366Z",
+        "time": 623,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 623
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/order-created_3976436170/creates-transaction-on-Avatax-side-for-new-order_3169230416/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/order-created_3976436170/creates-transaction-on-Avatax-side-for-new-order_3169230416/recording.har
@@ -1,0 +1,271 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/order-created/creates transaction on Avatax side for new order",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "79f25527d4bdf5fce81ab38c51821304",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 211,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "211"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"default-channel\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 773,
+          "content": {
+            "mimeType": "application/json",
+            "size": 773,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjEz\",\"privateMetafields\":{\"default-channel\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Wroclaw\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 7\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"account\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"123456\\\"},\\\"password\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"companyCode\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"DEFAULT\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:25 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "811"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-31T12:12:25.715Z",
+        "time": 282,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 282
+        }
+      },
+      {
+        "_id": "c70e4c64b88c5e2b1168a1fbe24983a1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 737,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-avalara-client",
+              "value": "Saleor; 1.0; JavascriptSdk; 22.7.0; Saleor-Avatax"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "737"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sandbox-rest.avatax.com"
+            }
+          ],
+          "headersSize": 432,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"type\":1,\"companyCode\":\"DEFAULT\",\"code\":\"29\",\"date\":\"2022-08-25T06:48:12.681Z\",\"customerCode\":\"0\",\"discount\":0,\"commit\":false,\"currencyCode\":\"USD\",\"lines\":[{\"number\":\"0\",\"quantity\":1,\"amount\":1.6,\"itemCode\":\"UHJvZHVjdFZhcmlhbnQ6Mzg3\",\"taxCode\":\"O9999999\",\"description\":\"Carrot Juice\",\"taxIncluded\":true,\"discounted\":false},{\"number\":\"\",\"quantity\":1,\"amount\":15.78,\"itemCode\":\"Shipping\",\"taxCode\":\"FR000000\",\"description\":\"\",\"taxIncluded\":true,\"discounted\":false}],\"addresses\":{\"shipTo\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"WROCLAW\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\",\"locationCode\":\"\"},\"shipFrom\":{\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"country\":\"PL\",\"postalCode\":\"53-601\"}}}"
+          },
+          "queryString": [],
+          "url": "https://sandbox-rest.avatax.com/api/v2/transactions/create"
+        },
+        "response": {
+          "bodySize": 7019,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 7019,
+            "text": "{\"id\":85008583925102,\"code\":\"29\",\"companyId\":7799660,\"date\":\"2022-08-25\",\"status\":\"Saved\",\"type\":\"SalesInvoice\",\"batchCode\":\"\",\"currencyCode\":\"USD\",\"exchangeRateCurrencyCode\":\"USD\",\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"customerVendorCode\":\"0\",\"customerCode\":\"0\",\"exemptNo\":\"\",\"reconciled\":false,\"locationCode\":\"\",\"reportingLocationCode\":\"\",\"purchaseOrderNo\":\"\",\"referenceCode\":\"\",\"salespersonCode\":\"\",\"taxOverrideType\":\"None\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"\",\"totalAmount\":14.13,\"totalExempt\":0.0,\"totalDiscount\":0.0,\"totalTax\":3.25,\"totalTaxable\":14.13,\"totalTaxCalculated\":3.25,\"adjustmentReason\":\"NotAdjusted\",\"adjustmentDescription\":\"\",\"locked\":false,\"region\":\"\",\"country\":\"PL\",\"version\":1,\"softwareVersion\":\"22.7.0.0\",\"originAddressId\":85008583925104,\"destinationAddressId\":85008583925103,\"exchangeRateEffectiveDate\":\"2022-08-25\",\"exchangeRate\":1.0,\"description\":\"\",\"email\":\"\",\"businessIdentificationNo\":\"\",\"modifiedDate\":\"2022-08-31T12:12:26.6857254Z\",\"modifiedUserId\":6479978,\"taxDate\":\"2022-08-25\",\"lines\":[{\"id\":85008583925108,\"transactionId\":85008583925102,\"lineNumber\":\"0\",\"boundaryOverrideId\":0,\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"Carrot Juice\",\"destinationAddressId\":85008583925103,\"originAddressId\":85008583925104,\"discountAmount\":0.0,\"discountTypeId\":0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"isSSTP\":false,\"itemCode\":\"UHJvZHVjdFZhcmlhbnQ6Mzg3\",\"lineAmount\":1.3000,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-25\",\"revAccount\":\"\",\"sourcing\":\"Destination\",\"tax\":0.3,\"taxableAmount\":1.3,\"taxCalculated\":0.3,\"taxCode\":\"O9999999\",\"taxCodeId\":9111,\"taxDate\":\"2022-08-25\",\"taxEngine\":\"\",\"taxOverrideType\":\"None\",\"businessIdentificationNo\":\"\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"\",\"taxIncluded\":true,\"details\":[{\"id\":85008583925129,\"transactionLineId\":85008583925108,\"transactionId\":85008583925102,\"addressId\":85008583925103,\"country\":\"PL\",\"region\":\"PL\",\"countyFIPS\":\"\",\"stateFIPS\":\"\",\"exemptAmount\":0.0000,\"exemptReasonId\":4,\"inState\":true,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"jurisdictionId\":200102,\"signatureCode\":\"\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0000,\"nonTaxableRuleId\":0,\"nonTaxableType\":\"RateRule\",\"rate\":0.230000,\"rateRuleId\":411502,\"rateSourceId\":0,\"serCode\":\"\",\"sourcing\":\"Destination\",\"tax\":0.3000,\"taxableAmount\":1.3000,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxTypeGroupId\":\"InputAndOutput\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxRegionId\":205102,\"taxCalculated\":0.3000,\"taxOverride\":0.0000,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"taxableUnits\":1.3000,\"nonTaxableUnits\":0.0000,\"exemptUnits\":0.0000,\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":1.3,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":0.3,\"reportingTaxCalculated\":0.3,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"lineLocationTypes\":[{\"documentLineLocationTypeId\":85008583925111,\"documentLineId\":85008583925108,\"documentAddressId\":85008583925104,\"locationTypeCode\":\"ShipFrom\"},{\"documentLineLocationTypeId\":85008583925112,\"documentLineId\":85008583925108,\"documentAddressId\":85008583925103,\"locationTypeCode\":\"ShipTo\"}],\"parameters\":[{\"name\":\"Transport\",\"value\":\"None\"},{\"name\":\"IsMarketplace\",\"value\":\"False\"},{\"name\":\"IsTriangulation\",\"value\":\"false\"},{\"name\":\"IsGoodsSecondHand\",\"value\":\"false\"}],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230C\",\"vatNumberTypeId\":0},{\"id\":85008583925109,\"transactionId\":85008583925102,\"lineNumber\":\"1\",\"boundaryOverrideId\":0,\"customerUsageType\":\"\",\"entityUseCode\":\"\",\"description\":\"\",\"destinationAddressId\":85008583925103,\"originAddressId\":85008583925104,\"discountAmount\":0.0,\"discountTypeId\":0,\"exemptAmount\":0.0,\"exemptCertId\":0,\"exemptNo\":\"\",\"isItemTaxable\":true,\"isSSTP\":false,\"itemCode\":\"Shipping\",\"lineAmount\":12.8300,\"quantity\":1.0,\"ref1\":\"\",\"ref2\":\"\",\"reportingDate\":\"2022-08-25\",\"revAccount\":\"\",\"sourcing\":\"Destination\",\"tax\":2.95,\"taxableAmount\":12.83,\"taxCalculated\":2.95,\"taxCode\":\"FR000000\",\"taxCodeId\":8550,\"taxDate\":\"2022-08-25\",\"taxEngine\":\"\",\"taxOverrideType\":\"None\",\"businessIdentificationNo\":\"\",\"taxOverrideAmount\":0.0,\"taxOverrideReason\":\"\",\"taxIncluded\":true,\"details\":[{\"id\":85008583925149,\"transactionLineId\":85008583925109,\"transactionId\":85008583925102,\"addressId\":85008583925103,\"country\":\"PL\",\"region\":\"PL\",\"countyFIPS\":\"\",\"stateFIPS\":\"\",\"exemptAmount\":0.0000,\"exemptReasonId\":4,\"inState\":true,\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"jurisdictionId\":200102,\"signatureCode\":\"\",\"stateAssignedNo\":\"\",\"jurisType\":\"CNT\",\"jurisdictionType\":\"Country\",\"nonTaxableAmount\":0.0000,\"nonTaxableRuleId\":0,\"nonTaxableType\":\"RateRule\",\"rate\":0.230000,\"rateRuleId\":411502,\"rateSourceId\":0,\"serCode\":\"\",\"sourcing\":\"Destination\",\"tax\":2.9500,\"taxableAmount\":12.8300,\"taxType\":\"Output\",\"taxSubTypeId\":\"O\",\"taxTypeGroupId\":\"InputAndOutput\",\"taxName\":\"Standard Rate\",\"taxAuthorityTypeId\":45,\"taxRegionId\":205102,\"taxCalculated\":2.9500,\"taxOverride\":0.0000,\"rateType\":\"Standard\",\"rateTypeCode\":\"S\",\"taxableUnits\":12.8300,\"nonTaxableUnits\":0.0000,\"exemptUnits\":0.0000,\"unitOfBasis\":\"PerCurrencyUnit\",\"isNonPassThru\":false,\"isFee\":false,\"reportingTaxableUnits\":12.83,\"reportingNonTaxableUnits\":0.0,\"reportingExemptUnits\":0.0,\"reportingTax\":2.95,\"reportingTaxCalculated\":2.95,\"liabilityType\":\"Seller\"}],\"nonPassthroughDetails\":[],\"lineLocationTypes\":[{\"documentLineLocationTypeId\":85008583925131,\"documentLineId\":85008583925109,\"documentAddressId\":85008583925104,\"locationTypeCode\":\"ShipFrom\"},{\"documentLineLocationTypeId\":85008583925132,\"documentLineId\":85008583925109,\"documentAddressId\":85008583925103,\"locationTypeCode\":\"ShipTo\"}],\"parameters\":[{\"name\":\"Transport\",\"value\":\"None\"},{\"name\":\"IsMarketplace\",\"value\":\"False\"},{\"name\":\"IsTriangulation\",\"value\":\"false\"},{\"name\":\"IsGoodsSecondHand\",\"value\":\"false\"}],\"hsCode\":\"\",\"costInsuranceFreight\":0.0,\"vatCode\":\"PLS-230D\",\"vatNumberTypeId\":0}],\"addresses\":[{\"id\":85008583925103,\"transactionId\":85008583925102,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"WROCLAW\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102},{\"id\":85008583925104,\"transactionId\":85008583925102,\"boundaryLevel\":\"Zip5\",\"line1\":\"Teczowa 7\",\"line2\":\"\",\"line3\":\"\",\"city\":\"Wroclaw\",\"region\":\"\",\"postalCode\":\"53-601\",\"country\":\"PL\",\"taxRegionId\":205102}],\"locationTypes\":[{\"documentLocationTypeId\":85008583925106,\"documentId\":85008583925102,\"documentAddressId\":85008583925104,\"locationTypeCode\":\"ShipFrom\"},{\"documentLocationTypeId\":85008583925107,\"documentId\":85008583925102,\"documentAddressId\":85008583925103,\"locationTypeCode\":\"ShipTo\"}],\"summary\":[{\"country\":\"PL\",\"region\":\"PL\",\"jurisType\":\"Country\",\"jurisCode\":\"PL\",\"jurisName\":\"POLAND\",\"taxAuthorityType\":45,\"stateAssignedNo\":\"\",\"taxType\":\"Output\",\"taxSubType\":\"O\",\"taxName\":\"Standard Rate\",\"rateType\":\"Standard\",\"taxable\":14.13,\"rate\":0.230000,\"tax\":3.25,\"taxCalculated\":3.25,\"nonTaxable\":0.00,\"exemption\":0.00}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 31 Aug 2022 12:12:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/companies/7799660/transactions/85008583925102"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "sameorigin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "serverduration",
+              "value": "00:00:00.0638981"
+            },
+            {
+              "name": "api-supported-versions",
+              "value": "2.0"
+            },
+            {
+              "name": "x-correlation-id",
+              "value": "9eb63c96-0309-4ba5-adc0-b1b9f03598aa"
+            },
+            {
+              "name": "x-avalara-uid",
+              "value": "9eb63c96-0309-4ba5-adc0-b1b9f03598aa"
+            }
+          ],
+          "headersSize": 644,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/companies/7799660/transactions/85008583925102",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-31T12:12:26.011Z",
+        "time": 921,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 921
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -1,0 +1,392 @@
+import { TaxBaseSubscriptionFragment } from "@/generated/graphql";
+import { createMocks, RequestMethod } from "node-mocks-http";
+import { AvataxConfig, FetchTaxesPayload } from "../backend/types";
+import { DocumentType } from "ava-typescript/lib/enums/DocumentType";
+import { TransactionModel } from "ava-typescript/models";
+import { BoundaryLevel } from "ava-typescript/lib/enums/BoundaryLevel";
+import { DocumentStatus } from "ava-typescript/lib/enums/DocumentStatus";
+import { JurisdictionType } from "ava-typescript/lib/enums/JurisdictionType";
+import { RateType } from "ava-typescript/lib/enums/RateType";
+
+type RequestConfiguration = {
+  method: RequestMethod;
+  event?: string;
+  domain?: string;
+  signature?: string;
+};
+export const mockRequest = (configuration: RequestConfiguration) => {
+  const method = configuration.method;
+  const { req, res } = createMocks({ method });
+  req.headers = {
+    "content-type": "application/json",
+  };
+  if (configuration.domain !== undefined) {
+    req.headers["saleor-domain"] = configuration.domain;
+  }
+  if (configuration.event !== undefined) {
+    req.headers["saleor-event"] = configuration.event;
+  }
+  if (configuration.signature !== undefined) {
+    req.headers["saleor-signature"] = configuration.signature;
+  }
+
+  return { req, res };
+};
+export const dummyCalculateTaxesPayloadForCheckout: TaxBaseSubscriptionFragment =
+  {
+    currency: "USD",
+    channel: { slug: "default-channel" },
+    pricesEnteredWithTax: true,
+    sourceObject: {
+      __typename: "Checkout",
+      id: "Q2hlY2tvdXQ6NzA0MzFhMDQtNWQzYy00YTdmLTlmNjItM2UzZmE3NzY1ZWZl",
+      date: "2022-08-31T07:10:25.385722+00:00",
+    },
+    discounts: [],
+    address: {
+      streetAddress1: "Teczowa 777",
+      streetAddress2: "",
+      city: "Wroclaw",
+      country: { code: "PL" },
+      countryArea: "",
+      postalCode: "53-601",
+    },
+    shippingPrice: { amount: 12.3 },
+    lines: [
+      {
+        chargeTaxes: true,
+        sourceLine: {
+          __typename: "CheckoutLine",
+          id: "Q2hlY2tvdXRMaW5lOmEyYzdiZWY1LWY4NjUtNDQ1OS05NWIyLTk5Yjg3YzcyZDQ5MQ==",
+          productVariant: {
+            id: "UHJvZHVjdFZhcmlhbnQ6MzQ4",
+            sku: "328223580",
+            name: "S",
+            product: { metafield: null, productType: { metafield: null } },
+          },
+        },
+        quantity: 3,
+        totalPrice: { amount: 60 },
+      },
+    ],
+  };
+
+export const dummyCalculateTaxesPayloadForOrder: TaxBaseSubscriptionFragment = {
+  currency: "USD",
+  channel: { slug: "default-channel" },
+  pricesEnteredWithTax: true,
+  sourceObject: {
+    __typename: "Order",
+    id: "T3JkZXI6MGUwMzNiYjktNWJhMy00ZmVmLWI2OGMtYmNiNzQ0ZjAyNGMz",
+    date: "2022-08-31T10:26:05.832256+00:00",
+  },
+  discounts: [],
+  address: {
+    streetAddress1: "Teczowa 777",
+    streetAddress2: "",
+    city: "Wroclaw",
+    country: { code: "PL" },
+    countryArea: "",
+    postalCode: "53-601",
+  },
+  shippingPrice: { amount: 12.3 },
+  lines: [
+    {
+      chargeTaxes: true,
+      sourceLine: {
+        __typename: "OrderLine",
+        id: "T3JkZXJMaW5lOmEwYTM0MWJmLWI3ZjMtNDIzYS04MjJiLTZhYTdkMTYzNDllOQ==",
+        productSku: "328223580",
+        productName: "Monospace Tee",
+        variant: {
+          id: "UHJvZHVjdFZhcmlhbnQ6MzQ4",
+          product: { metafield: null, productType: { metafield: null } },
+        },
+      },
+      quantity: 3,
+      totalPrice: { amount: 60 },
+    },
+  ],
+};
+
+export const dummyFetchTaxesPayload: FetchTaxesPayload = {
+  code: "234",
+  address: {
+    line1: "Teczowa 777",
+    line2: "",
+    line3: "",
+    city: "Wroclaw",
+    region: "Dolnoslaskie",
+    country: "PL",
+    postalCode: "53-601",
+    locationCode: "",
+  },
+  discount: 10,
+  date: "2022-05-04",
+  currency: "USD",
+  pricesEnteredWithTax: true,
+  lines: [
+    {
+      id: "1",
+      quantity: 1,
+      taxCode: "",
+      discounted: true,
+      chargeTaxes: true,
+      totalAmount: 20,
+      itemCode: "sku123",
+      description: "Apple Juice",
+    },
+    {
+      id: "",
+      quantity: 1,
+      taxCode: "FR000000",
+      discounted: true,
+      chargeTaxes: true,
+      totalAmount: 10,
+      itemCode: "Shipping",
+      description: "",
+    },
+  ],
+};
+
+export const dummyFetchTaxesResponse: TransactionModel = {
+  id: 0,
+  code: "cef4769e-4aff-401d-9d0b-460b40a687201",
+  companyId: 7799660,
+  date: new Date("2022-05-04"),
+  paymentDate: new Date("2022-05-04"),
+  status: DocumentStatus.Temporary,
+  type: DocumentType.SalesOrder,
+  batchCode: "",
+  currencyCode: "GBP",
+  exchangeRateCurrencyCode: "GBP",
+  customerUsageType: "",
+  entityUseCode: "",
+  customerVendorCode: "0",
+  customerCode: "0",
+  exemptNo: "",
+  reconciled: false,
+  locationCode: "",
+  reportingLocationCode: "",
+  purchaseOrderNo: "",
+  referenceCode: "",
+  salespersonCode: "",
+  totalAmount: 18.82,
+  totalExempt: 0.0,
+  totalDiscount: 0.0,
+  totalTax: 1.18,
+  totalTaxable: 18.82,
+  totalTaxCalculated: 1.18,
+  locked: false,
+  version: 1,
+  exchangeRateEffectiveDate: new Date("2022-05-04"),
+  exchangeRate: 1.0,
+  email: "admin@example.com",
+  modifiedDate: new Date("2022-05-04"),
+  modifiedUserId: 6479978,
+  taxDate: new Date("2022-05-04"),
+  lines: [
+    {
+      id: 0,
+      transactionId: 0,
+      lineNumber: "1",
+      customerUsageType: "",
+      entityUseCode: "",
+      description: "Apple Juice2",
+      discountAmount: 0.0,
+      exemptAmount: 0.0,
+      exemptCertId: 0,
+      exemptNo: "",
+      isItemTaxable: true,
+      itemCode: "21438541",
+      lineAmount: 9.41,
+      quantity: 1.0,
+      ref1: "",
+      ref2: "",
+      reportingDate: new Date("2022-05-04"),
+      tax: 0.59,
+      taxableAmount: 9.41,
+      taxCalculated: 0.59,
+      taxCode: "PH400834",
+      taxCodeId: 37453,
+      taxDate: new Date("2022-05-04"),
+      taxIncluded: true,
+      details: [
+        //@ts-ignore, avatax typing requires a fields that
+        // doesn't exist in the response fetched from the API directly
+        // The below line details are limited only to the fields that we use
+        {
+          id: 0,
+          rate: 0.0625,
+          tax: 0.59,
+          taxableAmount: 9.41,
+        },
+      ],
+      nonPassthroughDetails: [],
+      hsCode: "",
+      costInsuranceFreight: 0.0,
+      vatCode: "",
+      vatNumberTypeId: 0,
+    },
+    {
+      id: 0,
+      transactionId: 0,
+      lineNumber: "2",
+      customerUsageType: "",
+      entityUseCode: "",
+      description: "None",
+      discountAmount: 0.0,
+      exemptAmount: 0.0,
+      exemptCertId: 0,
+      exemptNo: "",
+      isItemTaxable: true,
+      itemCode: "Shipping",
+      lineAmount: 9.41,
+      quantity: 1.0,
+      ref1: "",
+      ref2: "",
+      reportingDate: new Date("2022-05-04"),
+      tax: 0.59,
+      taxableAmount: 9.41,
+      taxCalculated: 0.59,
+      taxCode: "FR000000",
+      taxCodeId: 8550,
+      taxDate: new Date("2022-05-04"),
+      taxIncluded: true,
+      details: [
+        //@ts-ignore, avatax typing requires a fields that
+        // doesn't exist in the response fetched from the API directly
+        // The below line details are limited only to the fields that we use
+        {
+          id: 0,
+          rate: 0.0625,
+          tax: 0.59,
+          taxableAmount: 9.41,
+        },
+      ],
+      nonPassthroughDetails: [],
+      hsCode: "",
+      costInsuranceFreight: 0.0,
+      vatCode: "",
+      vatNumberTypeId: 0,
+    },
+  ],
+  addresses: [
+    {
+      id: 0,
+      transactionId: 0,
+      boundaryLevel: BoundaryLevel.Zip5,
+      line1: "69 Place de la Gare",
+      line2: "",
+      line3: "",
+      city: "Colomiers",
+      region: "TX",
+      postalCode: "78923",
+      country: "US",
+      taxRegionId: 200144,
+      latitude: "",
+      longitude: "",
+      jurisdictions: [],
+    },
+    {
+      id: 0,
+      transactionId: 0,
+      boundaryLevel: BoundaryLevel.Zip5,
+      line1: "29 High Street",
+      line2: "",
+      line3: "",
+      city: "New York",
+      region: "NY",
+      postalCode: "10001",
+      country: "US",
+      taxRegionId: 2088629,
+      latitude: "40.748465",
+      longitude: "-73.99311",
+      jurisdictions: [],
+    },
+  ],
+  summary: [
+    {
+      country: "US",
+      region: "TX",
+      jurisType: JurisdictionType.State,
+      jurisCode: "48",
+      jurisName: "TEXAS",
+      taxAuthorityType: 45,
+      stateAssignedNo: "",
+      taxType: "Use",
+      taxSubType: "U",
+      taxName: "TX STATE TAX",
+      rateType: RateType.General,
+      taxable: 18.82,
+      rate: 0.0625,
+      tax: 1.18,
+      taxCalculated: 1.18,
+      nonTaxable: 0.0,
+      exemption: 0.0,
+      rateTypeCode: "",
+      taxGroup: "",
+    },
+  ],
+};
+
+export const dummyOrderCreatedPayload = {
+  __typename: "OrderCreated",
+  order: {
+    id: "T3JkZXI6MWUyZDNmZTItZWQyNy00OTY4LTk4ZmItNjg2YmI0YmExMTE0",
+    userEmail: "brandon.ruiz@example.com",
+    number: "29",
+    created: "2022-08-25T06:48:12.681067+00:00",
+    channel: { id: "Q2hhbm5lbDox", slug: "default-channel" },
+    shippingAddress: {
+      streetAddress1: "Teczowa 7",
+      streetAddress2: "",
+      city: "WROCLAW",
+      countryArea: "",
+      postalCode: "53-601",
+      country: { code: "PL" },
+    },
+    billingAddress: {
+      streetAddress1: "Teczowa 7",
+      streetAddress2: "",
+      city: "WROCLAW",
+      countryArea: "",
+      postalCode: "53-601",
+      country: { code: "PL" },
+    },
+    discounts: [],
+    total: { currency: "USD", net: { amount: 14.13 }, tax: { amount: 3.25 } },
+    shippingPrice: { gross: { amount: 15.78 } },
+    lines: [
+      {
+        productSku: null,
+        productName: "Carrot Juice",
+        quantity: 1,
+        variant: {
+          id: "UHJvZHVjdFZhcmlhbnQ6Mzg3",
+          product: {
+            chargeTaxes: false,
+            metafield: null,
+            productType: { metafield: null },
+          },
+        },
+        totalPrice: { net: { amount: 1.3 }, gross: { amount: 1.6 } },
+      },
+    ],
+  },
+};
+
+export const dummyAvataxConfig: AvataxConfig = {
+  shipFrom: {
+    fromCountry: "PL",
+    fromZip: "50-601",
+    fromState: "",
+    fromCity: "Wroclaw",
+    fromStreet: "Teczowa 7",
+  },
+  account: "12345",
+  password: "dummyKey",
+  companyCode: "DEFAULT",
+  active: true,
+  sandbox: true,
+};

--- a/backend/avataxApi.ts
+++ b/backend/avataxApi.ts
@@ -1,0 +1,73 @@
+import Avatax from "ava-typescript";
+import { AvataxConfig, FetchTaxesPayload } from "./types";
+import { DocumentType } from "ava-typescript/lib/enums/DocumentType";
+
+const getAvataxClient = (avataxConfig: AvataxConfig) =>
+  new Avatax({
+    appName: "Saleor",
+    appVersion: "1.0",
+    environment: avataxConfig.sandbox ? "sandbox" : "production",
+    machineName: "Saleor-Avatax",
+    timeout: 4000,
+  }).withSecurity({
+    username: avataxConfig.account,
+    password: avataxConfig.password,
+  });
+
+export const fetchTaxes = async (
+  taxPayload: FetchTaxesPayload,
+  avataxConfig: AvataxConfig,
+  transactionType: string
+) => {
+  const type =
+    transactionType === "SalesInvoice"
+      ? DocumentType.SalesInvoice
+      : DocumentType.SalesOrder;
+  const client = getAvataxClient(avataxConfig);
+  const address = taxPayload.address!;
+  const response = await client.createTransaction({
+    model: {
+      type: type,
+      companyCode: avataxConfig.companyCode,
+      code: taxPayload.code || "",
+      date: new Date(taxPayload.date),
+      customerCode: "0",
+      discount: taxPayload.discount,
+      commit: false,
+      currencyCode: taxPayload.currency,
+      // @ts-ignore Avatax typing requires unneeded fields as mandatory.
+      lines: taxPayload.lines.map((line) => ({
+        number: line.id,
+        quantity: line.quantity,
+        amount: line.totalAmount,
+        itemCode: line.itemCode,
+        taxCode: line.taxCode,
+        description: line.description,
+        taxIncluded: taxPayload.pricesEnteredWithTax,
+        discounted: line.discounted,
+        taxOverride: !line.chargeTaxes
+          ? {
+              type: "taxAmount",
+              taxAmount: 0,
+              reason: "Charge taxes for this product are turned off.",
+            }
+          : undefined,
+      })),
+      // @ts-ignore Avatax typing requires to provide not mandatory fields.
+      addresses: {
+        shipTo: address,
+        // @ts-ignore Avatax typing requires to provide not mandatory fields.
+        shipFrom: {
+          line1: avataxConfig.shipFrom.fromStreet,
+          line2: "",
+          line3: "",
+          city: avataxConfig.shipFrom.fromCity,
+          region: avataxConfig.shipFrom.fromState,
+          country: avataxConfig.shipFrom.fromCountry,
+          postalCode: avataxConfig.shipFrom.fromZip,
+        },
+      },
+    },
+  });
+  return response;
+};

--- a/backend/metaHandlers.ts
+++ b/backend/metaHandlers.ts
@@ -65,6 +65,7 @@ export const prepareResponseFromMetadata = (
       active,
       account,
       password,
+      companyCode,
       sandbox,
       shipFromCity,
       shipFromCountry,
@@ -78,6 +79,7 @@ export const prepareResponseFromMetadata = (
       [channelSlug]: {
         active: active || false,
         account: account || "",
+        companyCode: companyCode || "DEFAULT",
         password: password || "",
         sandbox: sandbox || true,
         shipFromCity: shipFromCity || "",
@@ -127,10 +129,41 @@ export const validateConfigurationBeforeSave = (
     .map(([channelSlug]) => channelSlug);
   if (activeWithoutApiKeys.length !== 0) {
     console.log(
-      "Avatax cannot be active for the channel as password is missing."
+      `Avatax cannot be active for the channels ${activeWithoutApiKeys.toString()} as password is missing.`
     );
     return {
-      message: `Avatax App cannot be active for channel: ${activeWithoutApiKeys.toString()}. The password is missing.`,
+      message: `Avatax App cannot be active for channel: ${activeWithoutApiKeys.toString()}. 
+      The password is missing.`,
+      isValid: false,
+    };
+  }
+  const activeWithoutAccount = Object.entries(channelsConfiguration)
+    .filter(
+      ([, configuration]) => configuration.active && !configuration.account
+    )
+    .map(([channelSlug]) => channelSlug);
+  if (activeWithoutAccount.length !== 0) {
+    console.log(
+      `Avatax cannot be active for the channels ${activeWithoutApiKeys.toString()} as account is missing.`
+    );
+    return {
+      message: `Avatax App cannot be active for channel:
+       ${activeWithoutAccount.toString()}. The account is missing.`,
+      isValid: false,
+    };
+  }
+  const activeWithoutAddress = Object.entries(channelsConfiguration)
+  .filter(
+    ([, configuration]) => configuration.active && (!configuration.shipFromCountry || !configuration.shipFromZip)
+  )
+  .map(([channelSlug]) => channelSlug);
+  if (activeWithoutAddress.length !== 0) {
+    console.log(
+      `Avatax cannot be active for the channels ${activeWithoutApiKeys.toString()} as address is not correct.`
+    );
+    return {
+      message: `Avatax App cannot be active for channel:
+       ${activeWithoutAddress.toString()}. The ship from address is not correct.`,
       isValid: false,
     };
   }

--- a/backend/taxHandlers.ts
+++ b/backend/taxHandlers.ts
@@ -1,0 +1,259 @@
+import { DEFAULT_TAX_CODE } from "@/constants";
+import {
+  OrderSubscriptionFragment,
+  TaxBaseSubscriptionFragment,
+} from "../generated/graphql";
+import { fetchTaxes } from "./avataxApi";
+
+import {
+  FetchTaxesLinePayload,
+  ResponseTaxPayload,
+  AvataxConfig,
+  FetchTaxesPayload,
+} from "./types";
+import {
+  getAvataxConfig,
+  avataxConfigIsValidToUse,
+  taxObjectIsValidToUse,
+} from "./utils";
+
+const prepareLinesPayload = (
+  taxData: TaxBaseSubscriptionFragment
+): Array<FetchTaxesLinePayload> => {
+  const lines = taxData.lines;
+  const linesPayload = lines.map((line, index) => {
+    const taxCode =
+      line.sourceLine.__typename === "OrderLine"
+        ? line.sourceLine.variant!.product.metafield ||
+          line.sourceLine.variant!.product.productType.metafield
+        : line.sourceLine.productVariant.product.metafield ||
+          line.sourceLine.productVariant.product.productType.metafield;
+    const itemCode =
+      line.sourceLine.__typename === "OrderLine"
+        ? line.sourceLine.productSku || line.sourceLine.variant!.id
+        : line.sourceLine.productVariant.sku ||
+          line.sourceLine.productVariant.id;
+
+    const description =
+      line.sourceLine.__typename === "OrderLine"
+        ? line.sourceLine.productName
+        : line.sourceLine.productVariant.name;
+
+    return {
+      id: String(index),
+      chargeTaxes: line.chargeTaxes,
+      taxCode: taxCode || DEFAULT_TAX_CODE,
+      quantity: line.quantity,
+      totalAmount: Number(line.totalPrice.amount),
+      discounted: taxData.discounts.length !== 0,
+      itemCode: itemCode,
+      description: description,
+    };
+  });
+  linesPayload.push({
+    id: "",
+    // FIXME: After introducing simple taxes we will be able to determine
+    // this value by fetching tax settings for taxes.
+    chargeTaxes: true,
+    taxCode: "FR000000",
+    quantity: 1,
+    totalAmount: taxData.shippingPrice.amount,
+    discounted: taxData.discounts.length !== 0,
+    itemCode: "Shipping",
+    description: "",
+  });
+  return linesPayload;
+};
+
+const prepareOrderCreatedLinesPayload = (
+  order: OrderSubscriptionFragment
+): Array<FetchTaxesLinePayload> => {
+  const lines = order.lines;
+  const linesPayload = lines.map((line, index) => {
+    const taxCode =
+      line.variant!.product.metafield ||
+      line.variant!.product.productType.metafield;
+    return {
+      id: String(index),
+      chargeTaxes: line.variant?.product.chargeTaxes || true,
+      taxCode: taxCode || DEFAULT_TAX_CODE,
+      quantity: line.quantity,
+      totalAmount: line.totalPrice.gross.amount,
+      itemCode: line.productSku || line.variant!.id,
+      description: line.productName,
+      discounted: order.discounts.length !== 0,
+    };
+  });
+  linesPayload.push({
+    id: "",
+    chargeTaxes: true,
+    taxCode: "FR000000",
+    quantity: 1,
+    totalAmount: order.shippingPrice.gross.amount,
+    discounted: false,
+    itemCode: "Shipping",
+    description: "",
+  });
+  return linesPayload;
+};
+const calculateTaxes = async (
+  taxData: TaxBaseSubscriptionFragment,
+  avataxConfig: AvataxConfig
+) => {
+  const lines = prepareLinesPayload(taxData);
+  const payload: FetchTaxesPayload = {
+    address: {
+      line1: taxData.address!.streetAddress1,
+      line2: taxData.address!.streetAddress2,
+      line3: "",
+      city: taxData.address!.city,
+      region: taxData.address!.countryArea,
+      country: taxData.address!.country.code,
+      postalCode: taxData.address!.postalCode,
+      locationCode: "",
+    },
+    discount:
+      taxData.discounts.reduce(
+        (total, discount) => total + discount.amount.amount,
+        0
+      ) || 0,
+    date: taxData.sourceObject.date,
+    currency: taxData.currency,
+    pricesEnteredWithTax: taxData.pricesEnteredWithTax,
+    lines: lines,
+  };
+  try {
+    const taxResponse =
+      lines.length !== 0
+        ? await fetchTaxes(payload, avataxConfig, "SalesOrder")
+        : undefined;
+    if (!taxResponse) {
+      const data: ResponseTaxPayload = {
+        shipping_price_gross_amount: String(taxData.shippingPrice.amount),
+        shipping_price_net_amount: String(taxData.shippingPrice.amount),
+        shipping_tax_rate: "0",
+        lines: taxData.lines.map((line) => ({
+          tax_rate: "0",
+          total_gross_amount: String(line.totalPrice.amount),
+          total_net_amount: String(line.totalPrice.amount),
+        })),
+      };
+      return { body: { data: data }, status: 200 };
+    }
+    const shipping = taxResponse.lines.find(
+      (line) => line.itemCode === "Shipping"
+    );
+    const shippingDiscount = shipping?.discountAmount || 0;
+    const shippingNet =
+      (shipping?.lineAmount
+        ? shipping.lineAmount
+        : taxData.shippingPrice.amount) - shippingDiscount;
+    const shippingTax = shipping?.tax ? shipping.tax : 0;
+    const taxRate = shipping?.details.reduce(
+      (currentRate, detail) => currentRate + (detail?.rate || 0),
+      0
+    );
+    const data: ResponseTaxPayload = {
+      shipping_price_gross_amount: (shippingNet + shippingTax).toFixed(2),
+      shipping_price_net_amount: shippingNet.toFixed(2),
+      // Tax rate send to Saleor should be in decimal.
+      // when tax rate is 23%, the value that we send should be
+      // taxRate = 23
+      shipping_tax_rate: ((taxRate || 0) * 100).toFixed(2),
+      lines: lines
+        .filter((line) => line.itemCode !== "Shipping")
+        .map((line) => {
+          const lineTax = taxResponse.lines.find(
+            (taxLine) => taxLine?.lineNumber === line.id
+          );
+          const discountAmount = lineTax?.discountAmount || 0;
+          const totalNetAmount =
+            (lineTax?.lineAmount || line.totalAmount) - discountAmount;
+          const totalTaxAmount = lineTax?.tax || 0;
+          const totalGrossAmount = totalNetAmount + totalTaxAmount;
+          const lineTaxRate = line.chargeTaxes
+            ? lineTax?.details.reduce(
+                (currentRate, detail) => currentRate + (detail?.rate || 0),
+                0
+              )
+            : 0;
+          return {
+            total_gross_amount: totalGrossAmount.toFixed(2),
+            total_net_amount: totalNetAmount.toFixed(2),
+            // Tax rate send to Saleor should be in decimal.
+            // when tax rate is 23%, the value that we send should be
+            // taxRate = 23
+            tax_rate: ((lineTaxRate || 0) * 100).toFixed(2),
+          };
+        }),
+    };
+    return { body: data, status: 200 };
+  } catch (error) {
+    const error_msg = `Failed to fetch Avatax response ${error}`;
+    console.warn(error_msg);
+    return { body: { error: { message: error_msg } }, status: 404 };
+  }
+};
+
+export const calculateTaxesHandler = async (
+  taxObject: TaxBaseSubscriptionFragment,
+  saleorDomain: string
+) => {
+  const avataxConfig = await getAvataxConfig(
+    saleorDomain,
+    taxObject.channel.slug
+  );
+  const validData = avataxConfigIsValidToUse(avataxConfig);
+
+  if (!validData.isValid) {
+    return {
+      body: { error: { message: validData.message } },
+      status: validData.status,
+    };
+  }
+
+  const validTaxObject = taxObjectIsValidToUse(taxObject);
+  if (!validTaxObject.isValid) {
+    return {
+      body: { error: { message: validData.message } },
+      status: validData.status,
+    };
+  }
+  return await calculateTaxes(taxObject, avataxConfig);
+};
+
+export const createTransaction = async (
+  order: OrderSubscriptionFragment,
+  avataxConfig: AvataxConfig
+) => {
+  const lines = prepareOrderCreatedLinesPayload(order);
+  const address = order.shippingAddress || order.billingAddress;
+  const payload: FetchTaxesPayload = {
+    code: order.number,
+    address: {
+      line1: address!.streetAddress1,
+      line2: address!.streetAddress2,
+      line3: "",
+      city: address!.city,
+      region: address!.countryArea,
+      country: address!.country.code,
+      postalCode: address!.postalCode,
+      locationCode: "",
+    },
+    discount: 0,
+    date: order.created,
+    currency: order.total.currency,
+    // FIXME: After introducing simple taxes we will be able to determine
+    // this value by fetching tax settings for taxes.
+    pricesEnteredWithTax: true,
+    lines: lines,
+  };
+  try {
+    await fetchTaxes(payload, avataxConfig, "SalesInvoice");
+    return { body: {}, status: 200 };
+  } catch (error) {
+    const error_msg = `Failed to send order to Avatax: ${error}`;
+    console.error(error_msg);
+    return { body: { error: { message: error_msg } }, status: 404 };
+  }
+};

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -1,0 +1,59 @@
+export type FetchTaxesLinePayload = {
+  id: string;
+  quantity: number;
+  taxCode?: string | null;
+  discounted: boolean;
+  chargeTaxes: boolean;
+  totalAmount: number;
+  itemCode: string;
+  description: string;
+};
+export type FetchTaxesPayload = {
+  code?: string;
+  address: FetchTaxesAddressPayload;
+  discount: number;
+  date: string;
+  currency: string;
+  pricesEnteredWithTax: boolean;
+  lines: Array<FetchTaxesLinePayload>;
+};
+export type FetchTaxesAddressPayload = {
+  line1: string;
+  line2: string;
+  line3: string;
+  city: string;
+  region: string;
+  country: string;
+  postalCode: string;
+  locationCode: string;
+};
+export interface LineTaxResponsePayload {
+  total_gross_amount: string;
+  total_net_amount: string;
+  tax_rate: string;
+}
+
+export interface ResponseTaxPayload {
+  shipping_price_gross_amount: string;
+  shipping_price_net_amount: string;
+  shipping_tax_rate: string;
+  lines: Array<LineTaxResponsePayload>;
+}
+
+// FIXME:
+export interface AvataxAddress {
+  fromCountry: string;
+  fromZip: string;
+  fromState: string;
+  fromCity: string;
+  fromStreet: string;
+}
+
+export interface AvataxConfig {
+  shipFrom: AvataxAddress;
+  account: string;
+  password: string;
+  companyCode: string;
+  sandbox: boolean;
+  active: boolean;
+}

--- a/backend/utils.ts
+++ b/backend/utils.ts
@@ -1,0 +1,91 @@
+import { TaxBaseSubscriptionFragment } from "@/generated/graphql";
+import { fetchChannelsSettings } from "./metaHandlers";
+import { AvataxConfig } from "./types";
+
+export const getAvataxConfig = async (
+  saleorDomain: string,
+  channelSlug: string
+) => {
+  const settings = await fetchChannelsSettings(saleorDomain, [channelSlug]);
+
+  type ConfigurationPayloadKey = keyof typeof settings;
+  const channelKey = channelSlug as ConfigurationPayloadKey;
+  const channelSettings = settings?.[channelKey];
+
+  const avataxConfig: AvataxConfig = {
+    shipFrom: {
+      fromCountry: channelSettings?.shipFromCountry || "",
+      fromZip: channelSettings?.shipFromZip || "",
+      fromState: channelSettings?.shipFromState || "",
+      fromCity: channelSettings?.shipFromCity || "",
+      fromStreet: channelSettings?.shipFromStreet || "",
+    },
+    account: channelSettings?.account || "",
+    password: channelSettings?.password || "",
+    sandbox: channelSettings?.sandbox || true,
+    active: channelSettings?.active || false,
+    companyCode: channelSettings?.companyCode || "DEFAULT",
+  };
+  return avataxConfig;
+};
+
+export const avataxConfigIsValidToUse = (avataxConfig: AvataxConfig) => {
+  const defaultResponse = {
+    isValid: true,
+    status: 200,
+    message: "",
+  };
+
+  if (!avataxConfig.active) {
+    console.log("Avatax is not active.");
+    return {
+      ...defaultResponse,
+      message: "Avatax is not active.",
+      isValid: false,
+    };
+  } else if (!avataxConfig.password) {
+    console.log("Avatax password was not provided.");
+
+    return {
+      message: "Avatax password was not provided.",
+      status: 404,
+      isValid: false,
+    };
+  }
+
+  return {
+    ...defaultResponse,
+    message: "",
+  };
+};
+
+export const taxObjectIsValidToUse = (
+  taxObject: TaxBaseSubscriptionFragment
+) => {
+  const defaultResponse = {
+    isValid: true,
+    status: 200,
+    message: "",
+  };
+  if (!taxObject.address) {
+    console.log("Missing address in provided tax object");
+    return {
+      isValid: false,
+      status: 404,
+      message: "Missing address.",
+    };
+  }
+
+  const orderLineWithoutVariant = taxObject.lines.filter(
+    (line) =>
+      line.sourceLine.__typename === "OrderLine" && !line.sourceLine.variant
+  );
+  if (orderLineWithoutVariant.length !== 0) {
+    return {
+      isValid: false,
+      status: 404,
+      message: "Can't calculate taxes. Variant doesn't exists.",
+    };
+  }
+  return defaultResponse;
+};

--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,7 @@
 export const appName = "Saleor Avatax";
 
+export const DEFAULT_TAX_CODE = "O9999999"
+
 export const isSsr = typeof window === "undefined";
 
 export type ServerEnvVar = "settingsEncryptionSecret";

--- a/frontend/components/templates/ConfigurationDetails/ConfigurationDetails.tsx
+++ b/frontend/components/templates/ConfigurationDetails/ConfigurationDetails.tsx
@@ -138,6 +138,22 @@ const ConfigurationDetails: React.FC<ConfigurationDetailsProps> = ({
                 />
                 <VerticalSpacer />
                 <Controller
+                  name="companyCode"
+                  control={control}
+                  defaultValue={configuration?.companyCode}
+                  render={({ field }) => (
+                    <TextField
+                      label="Company code"
+                      fullWidth
+                      name={field.name}
+                      value={field.value}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                    />
+                  )}
+                />
+                <VerticalSpacer />
+                <Controller
                   name="active"
                   control={control}
                   defaultValue={configuration?.active}

--- a/frontend/components/templates/ConfigurationDetails/data.ts
+++ b/frontend/components/templates/ConfigurationDetails/data.ts
@@ -16,6 +16,7 @@ export const getFormDefaultValues = (
 ): ChannelConfigurationForm => ({
   account: configuration?.account || "",
   password: configuration?.password || "",
+  companyCode: configuration?.companyCode || "DEFAULT",
   active: configuration?.active || false,
   sandbox: configuration?.sandbox || true,
   ...getFormDefaultAddress(configuration),

--- a/graphql/fragments/TaxBaseFragment.graphql
+++ b/graphql/fragments/TaxBaseFragment.graphql
@@ -6,6 +6,8 @@ fragment TaxBaseLineSubscripton on TaxableObjectLine {
       id
       productVariant: variant {
         id
+        sku
+        name
         product {
           metafield(key: "avatax_tax_code")
           productType {
@@ -16,6 +18,8 @@ fragment TaxBaseLineSubscripton on TaxableObjectLine {
     }
     ... on OrderLine {
       id
+      productSku
+      productName
       variant {
         id
         product {
@@ -28,9 +32,6 @@ fragment TaxBaseLineSubscripton on TaxableObjectLine {
     }
   }
   quantity
-  unitPrice {
-    amount
-  }
   totalPrice {
     amount
   }
@@ -46,6 +47,18 @@ fragment TaxBaseSubscription on TaxableObject {
   currency
   channel {
     slug
+  }
+  pricesEnteredWithTax
+  sourceObject{
+    __typename
+    ... on Order{
+      id
+      date: updatedAt
+    }
+    ... on Checkout{
+      id
+      date: lastChange
+    }
   }
   discounts {
     ...TaxDiscountSubscription

--- a/graphql/subscriptions/OrderCreatedSubscription.graphql
+++ b/graphql/subscriptions/OrderCreatedSubscription.graphql
@@ -2,13 +2,21 @@ fragment OrderLineFragment on OrderLine {
   productSku
   productName
   quantity
-  unitPrice {
-    net {
-      amount
+  variant {
+    id
+    product {
+      chargeTaxes
+      metafield(key: "avatax_tax_code")
+      productType {
+        metafield(key: "avatax_tax_code")
+      }
     }
   }
   totalPrice {
-    tax {
+    net {
+      amount
+    }
+    gross {
       amount
     }
   }
@@ -16,7 +24,7 @@ fragment OrderLineFragment on OrderLine {
 
 fragment OrderSubscription on Order {
   id
-  userEmail
+  number
   created
   channel {
     id
@@ -28,7 +36,13 @@ fragment OrderSubscription on Order {
   billingAddress {
     ...AddressFragment
   }
+  discounts {
+    amount {
+      amount
+    }
+  }
   total {
+    currency
     net {
       amount
     }
@@ -37,7 +51,7 @@ fragment OrderSubscription on Order {
     }
   }
   shippingPrice {
-    net {
+    gross {
       amount
     }
   }

--- a/pages/api/webhooks/checkout-calculate-taxes.ts
+++ b/pages/api/webhooks/checkout-calculate-taxes.ts
@@ -8,18 +8,20 @@ import type { Handler } from "retes";
 import { toNextHandler } from "retes/adapter";
 import { Response } from "retes/response";
 import { CalculateTaxesEventSubscriptionFragment } from "@/generated/graphql";
+import { calculateTaxesHandler } from "@/backend/taxHandlers";
 
-const handler: Handler = (request) => {
+const handler: Handler = async (request) => {
   const saleorDomain = request.headers[SALEOR_DOMAIN_HEADER];
   const payload: CalculateTaxesEventSubscriptionFragment =
     typeof request.body === "string" ? JSON.parse(request.body) : request.body;
 
   if (payload?.__typename === "CalculateTaxes") {
     const taxObject = payload.taxBase!;
+    return await calculateTaxesHandler(taxObject, saleorDomain);
   }
   return Response.BadRequest({
+    error: { message: "Incorrect payload event." },
     success: false,
-    message: "Incorrect payload event.",
   });
 };
 

--- a/pages/api/webhooks/order-calculate-taxes.ts
+++ b/pages/api/webhooks/order-calculate-taxes.ts
@@ -8,8 +8,9 @@ import {
 import type { Handler } from "retes";
 import { toNextHandler } from "retes/adapter";
 import { Response } from "retes/response";
+import { calculateTaxesHandler } from "@/backend/taxHandlers";
 
-const handler: Handler = (request) => {
+const handler: Handler = async (request) => {
   const saleorDomain = request.headers[SALEOR_DOMAIN_HEADER];
 
   const payload: CalculateTaxesEventSubscriptionFragment =
@@ -17,6 +18,7 @@ const handler: Handler = (request) => {
 
   if (payload?.__typename === "CalculateTaxes") {
     const taxObject = payload.taxBase!;
+    return await calculateTaxesHandler(taxObject, saleorDomain);
   }
   return Response.BadRequest({
     success: false,

--- a/pages/api/webhooks/order-created.ts
+++ b/pages/api/webhooks/order-created.ts
@@ -9,15 +9,22 @@ import {
 import type { Handler } from "retes";
 import { toNextHandler } from "retes/adapter";
 import { Response } from "retes/response";
+import { createTransaction } from "@/backend/taxHandlers";
+import { getAvataxConfig } from "@/backend/utils";
 
-const handler: Handler = (request) => {
+const handler: Handler = async (request) => {
   const saleorDomain = request.headers[SALEOR_DOMAIN_HEADER];
 
   const body: OrderCreatedEventSubscriptionFragment =
     typeof request.body === "string" ? JSON.parse(request.body) : request.body;
 
   if (body?.__typename === "OrderCreated") {
-    console.log(body)    
+    const order = body.order!;
+    const avataxConfig = await getAvataxConfig(
+      saleorDomain,
+      order.channel.slug
+    );
+    return createTransaction(order, avataxConfig);
   }
   return Response.BadRequest({
     success: false,

--- a/types/api.ts
+++ b/types/api.ts
@@ -9,6 +9,7 @@ export type ConfigurationPayloadShipFrom = {
 export interface ChannelConfigurationBase {
   account: string
   password: string;
+  companyCode: string;
   active: boolean;
   sandbox: boolean;
 }


### PR DESCRIPTION
Add support for webhooks responsible for calculating taxes. It uses Avatax API to return calculated taxes.

Note: All fixme related to simple taxes can be left here. I will create an additional internal taxes for them as we need to wait for simple taxes implementation.